### PR TITLE
fix: add trailing slash only to directories when auto completing paths

### DIFF
--- a/server/src/main/kotlin/io/typestream/filesystem/FileSystem.kt
+++ b/server/src/main/kotlin/io/typestream/filesystem/FileSystem.kt
@@ -161,18 +161,24 @@ class FileSystem(sourcesConfig: SourcesConfig, private val dispatcher: Coroutine
 
         val children = if (targetPathBase == "/") root.children() else root.findInode(targetPathBase)?.children()
 
+        val pwdPrefix = if (pwd == "/") "/" else "$pwd/"
+
         children?.forEach {
             val currentNodePath = it.path()
             if (currentNodePath.startsWith(targetPath)) {
-                val suggestion = if (isAbsolute) {
+                var suggestion = if (isAbsolute) {
                     currentNodePath
                 } else if (isSubPath) {
-                  currentNodePath.removePrefix("$pwd/")
+                    currentNodePath.removePrefix(pwdPrefix)
                 } else {
                     it.name
                 }
 
-                add("$suggestion/")
+                if (it is Directory) {
+                    suggestion += "/"
+                }
+
+                add(suggestion)
             }
         }
     }

--- a/server/src/test/kotlin/io/typestream/filesystem/FileSystemTest.kt
+++ b/server/src/test/kotlin/io/typestream/filesystem/FileSystemTest.kt
@@ -102,6 +102,7 @@ internal class FileSystemTest {
             Arguments.of("/d", "/", listOf("/dev/")),
             Arguments.of("ka", "/dev", listOf("kafka/")),
             Arguments.of("kafka/lo", "/dev", listOf("kafka/local/")),
+            Arguments.of("dev/kafka/lo", "/", listOf("dev/kafka/local/")),
             Arguments.of(
                 "/dev/kafka/local/", "/", listOf(
                     "/dev/kafka/local/brokers/",
@@ -121,4 +122,23 @@ internal class FileSystemTest {
                 assertThat(fileSystem.completePath(incompletePath, pwd)).contains(*suggestions.toTypedArray())
             }
         }
+
+    @Test
+    fun `only completes directories with trailing slash`() = runTest(testDispatcher) {
+        fileSystem.use {
+            testKafka.produceRecords("authors", buildAuthor("Chimamanda Ngozi Adichie"))
+
+            launch {
+                fileSystem.watch()
+            }
+
+
+            assertThat(
+                fileSystem.completePath(
+                    "dev/kafka/local/topics/a",
+                    "/"
+                )
+            ).contains("dev/kafka/local/topics/authors")
+        }
+    }
 }


### PR DESCRIPTION
There's also a bonus bug fix in this commit: releative path completion was broken when pww = '/'