### PR TITLE
chore: use version catalog everywhere for deps

### DIFF
--- a/buildSrc/src/main/kotlin/typestream.kotlin-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/typestream.kotlin-conventions.gradle.kts
@@ -12,7 +12,6 @@ group = "io.typestream"
 
 repositories {
     mavenCentral()
-    maven("https://packages.confluent.io/maven/") //TODO this doesn't belong here
 }
 
 dependencies {

--- a/libs/k8s-client/build.gradle.kts
+++ b/libs/k8s-client/build.gradle.kts
@@ -3,5 +3,5 @@ plugins {
 }
 
 dependencies {
-    implementation("io.fabric8:kubernetes-client:6.9.0")
+    implementation(libs.kubernetes.client)
 }

--- a/libs/testing/build.gradle.kts
+++ b/libs/testing/build.gradle.kts
@@ -12,7 +12,6 @@ dependencies {
     implementation(project(":libs:konfig"))
     implementation(libs.avro)
     implementation(libs.bundles.kafka)
-    implementation("org.testcontainers:redpanda:${libs.versions.testcontainers.get()}")
-
-    implementation("io.confluent:kafka-avro-serializer:7.1.0")
+    implementation(libs.test.containers.redpanda)
+    implementation(libs.kafka.avro.serializer)
 }

--- a/server/build.gradle.kts
+++ b/server/build.gradle.kts
@@ -5,6 +5,11 @@ plugins {
     application
 }
 
+repositories {
+    mavenCentral()
+    maven("https://packages.confluent.io/maven/")
+}
+
 application {
     mainClass.set("io.typestream.Main")
 }
@@ -16,19 +21,17 @@ dependencies {
     implementation(project(":libs:version-info"))
     implementation(project(":stub"))
 
+    implementation(libs.avro)
     implementation(libs.bundles.kafka)
     implementation(libs.bundles.sf4j)
-    implementation(libs.avro)
-
-    implementation("com.squareup.okhttp3:okhttp:4.10.0")
-
     runtimeOnly(libs.grpc.netty)
-    implementation("io.grpc:grpc-services:${libs.versions.grpc.get()}")
+    implementation(libs.grpc.services)
+    implementation(libs.okhttp)
 
     testImplementation(project(":libs:testing"))
     testImplementation(libs.bundles.testcontainers)
-    testImplementation("org.testcontainers:redpanda:${libs.versions.testcontainers.get()}")
-    testImplementation("io.grpc:grpc-testing:${libs.versions.grpc.get()}")
+    testImplementation(libs.test.containers.redpanda)
+    testImplementation(libs.grpc.testing)
 }
 
 jib {

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,27 +1,47 @@
 rootProject.name = "typestream"
-include("libs:testing", "libs:k8s-client", "libs:konfig", "libs:option", "libs:version-info", "protos", "stub", "server", "tools")
+
+include(
+    "libs:testing",
+    "libs:k8s-client",
+    "libs:konfig",
+    "libs:option",
+    "libs:version-info",
+    "protos",
+    "stub",
+    "server",
+    "tools"
+)
 
 dependencyResolutionManagement {
     versionCatalogs {
         create("libs") {
+            version("avro", "1.11.2")
+            version("confluent", "7.1.0")
             version("grpc", "1.57.2")
             version("grpcKotlin", "1.3.1")
-            version("protobuf", "3.24.2")
-            version("slf4j", "2.0.7")
             version("kafka", "3.1.0")
-            version("testcontainers", "1.19.0")
-            version("avro", "1.11.2")
+            version("kubernetes-client", "6.9.0")
+            version("okhttp", "4.10.0")
+            version("protobuf", "3.24.2")
             version("rocksdbjni", "6.29.4.1")
+            version("slf4j", "2.0.7")
+            version("testcontainers", "1.19.0")
 
             library("avro", "org.apache.avro", "avro").versionRef("avro")
-            library("rocksdbjni", "org.rocksdb", "rocksdbjni").versionRef("rocksdbjni")
+            library("grpc-netty", "io.grpc", "grpc-netty").versionRef("grpc")
+            library("grpc-services", "io.grpc", "grpc-services").versionRef("grpc")
+            library("grpc-testing", "io.grpc", "grpc-testing").versionRef("grpc")
             library("kafka-clients", "org.apache.kafka", "kafka-clients").versionRef("kafka")
             library("kafka-streams", "org.apache.kafka", "kafka-streams").versionRef("kafka")
-            library("grpc-netty", "io.grpc", "grpc-netty").versionRef("grpc")
+            library("kafka-avro-serializer", "io.confluent", "kafka-avro-serializer").versionRef("confluent")
+            library("kubernetes-client", "io.fabric8", "kubernetes-client").versionRef("kubernetes-client")
+            library("okhttp", "com.squareup.okhttp3", "okhttp").versionRef("okhttp")
+            library("rocksdbjni", "org.rocksdb", "rocksdbjni").versionRef("rocksdbjni")
             library("slf4j-simple", "org.slf4j", "slf4j-simple").versionRef("slf4j")
             library("slf4j-api", "org.slf4j", "slf4j-api").versionRef("slf4j")
             library("test-containers", "org.testcontainers", "testcontainers-bom").versionRef("testcontainers")
             library("test-containers-junit", "org.testcontainers", "junit-jupiter").versionRef("testcontainers")
+            library("test-containers-redpanda", "org.testcontainers", "redpanda").versionRef("testcontainers")
 
             bundle("sf4j", listOf("slf4j-api", "slf4j-simple"))
             bundle("kafka", listOf("kafka-clients", "kafka-streams", "rocksdbjni"))

--- a/tools/build.gradle.kts
+++ b/tools/build.gradle.kts
@@ -5,23 +5,28 @@ plugins {
     application
 }
 
+repositories {
+    mavenCentral()
+    maven("https://packages.confluent.io/maven/")
+}
+
 application {
     mainClass.set("io.typestream.tools.Main")
 }
 
 dependencies {
-    implementation(project(":libs:testing"))
     implementation(project(":libs:konfig"))
+    implementation(project(":libs:k8s-client"))
+    implementation(project(":libs:testing"))
     implementation(project(":libs:version-info"))
-    implementation("io.fabric8:kubernetes-client:6.8.1")
 
-    implementation(libs.bundles.sf4j)
-    implementation(libs.bundles.kafka)
     implementation(libs.avro)
-    implementation("io.confluent:kafka-avro-serializer:7.3.0")
+    implementation(libs.bundles.kafka)
+    implementation(libs.bundles.sf4j)
+    implementation(libs.kafka.avro.serializer)
 
     testImplementation(libs.bundles.testcontainers)
-    testImplementation("org.testcontainers:redpanda:${libs.versions.testcontainers.get()}")
+    testImplementation(libs.test.containers.redpanda)
 }
 
 jib {


### PR DESCRIPTION
While streamlining the way we do dependencies, I realised I forgot to use the k8sclient in the tools project so I also fixed that.