### PR TITLE
feat: introduce sync refresh

### DIFF
--- a/server/src/main/kotlin/io/typestream/Worker.kt
+++ b/server/src/main/kotlin/io/typestream/Worker.kt
@@ -23,12 +23,9 @@ class Worker(konfig: Konfig) {
 
         logger.info { "starting filesystem" }
         val fileSystem = FileSystem(sourcesConfig, dispatcher)
-        launch { fileSystem.watch() }
 
-        // we wait so that types information is available when we compile the program
-        // this solution is suboptimal, because we don't need to watch the filesystem.
-        // We need something like filesystem.fetch() to fetch all relevant types synchronously once
-        until { fileSystem.isReady() }
+        fileSystem.refresh()
+
         logger.info { "file system is ready" }
 
         val vm = Vm(fileSystem, Scheduler(true, dispatcher))

--- a/server/src/main/kotlin/io/typestream/filesystem/Directory.kt
+++ b/server/src/main/kotlin/io/typestream/filesystem/Directory.kt
@@ -10,4 +10,8 @@ open class Directory(name: String) : Inode(name) {
     override suspend fun watch() {
         children.forEach { it.watch() }
     }
+
+    override fun refresh() {
+        children.forEach { it.refresh() }
+    }
 }

--- a/server/src/main/kotlin/io/typestream/filesystem/Inode.kt
+++ b/server/src/main/kotlin/io/typestream/filesystem/Inode.kt
@@ -6,6 +6,7 @@ abstract class Inode(val name: String) {
 
     abstract fun stat(): String
     abstract suspend fun watch()
+    abstract fun refresh()
 
     fun findInode(path: String): Inode? {
         var current = this

--- a/server/src/main/kotlin/io/typestream/filesystem/kafka/Broker.kt
+++ b/server/src/main/kotlin/io/typestream/filesystem/kafka/Broker.kt
@@ -7,4 +7,6 @@ class Broker(name: String) : Inode(name) {
     override fun stat() = TODO("broker stat")
 
     override suspend fun watch() {}
+
+    override fun refresh() {}
 }

--- a/server/src/main/kotlin/io/typestream/filesystem/kafka/ConsumerGroup.kt
+++ b/server/src/main/kotlin/io/typestream/filesystem/kafka/ConsumerGroup.kt
@@ -7,4 +7,6 @@ class ConsumerGroup(name: String) : Inode(name) {
     override fun stat() = TODO("consumer group stat")
 
     override suspend fun watch() {}
+
+    override fun refresh() {}
 }

--- a/server/src/main/kotlin/io/typestream/filesystem/kafka/Topic.kt
+++ b/server/src/main/kotlin/io/typestream/filesystem/kafka/Topic.kt
@@ -8,4 +8,6 @@ class Topic(name: String, private val kafkaAdminClient: KafkaAdminClient) : Inod
     override fun stat() = kafkaAdminClient.topicInfo(name)
 
     override suspend fun watch() {}
+
+    override fun refresh() {}
 }

--- a/server/src/test/kotlin/io/typestream/filesystem/catalog/CatalogTest.kt
+++ b/server/src/test/kotlin/io/typestream/filesystem/catalog/CatalogTest.kt
@@ -6,36 +6,25 @@ import io.typestream.filesystem.FileSystem
 import io.typestream.testing.RedpandaContainerWrapper
 import io.typestream.testing.avro.buildUser
 import io.typestream.testing.konfig.testKonfig
-import io.typestream.testing.until
-import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.launch
-import kotlinx.coroutines.test.UnconfinedTestDispatcher
-import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.Dispatchers
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.tuple
 import org.junit.jupiter.api.Test
 import org.testcontainers.junit.jupiter.Container
 import org.testcontainers.junit.jupiter.Testcontainers
 
-@ExperimentalCoroutinesApi
 @Testcontainers
 internal class CatalogTest {
 
     @Container
     private val testKafka = RedpandaContainerWrapper()
 
-    private val testDispatcher = UnconfinedTestDispatcher()
-
     @Test
-    fun `fetches avro schema`() = runTest {
+    fun `fetches avro schema`() {
         testKafka.produceRecords("users", buildUser("Grace Hopper"))
-        val catalog = Catalog(SourcesConfig(testKonfig(testKafka)), testDispatcher)
+        val catalog = Catalog(SourcesConfig(testKonfig(testKafka)), Dispatchers.IO)
 
-        val job = launch(testDispatcher) { catalog.watch() }
-
-        until {
-            requireNotNull(catalog["${FileSystem.KAFKA_CLUSTERS_PREFIX}/local/topics/users"])
-        }
+        catalog.refresh()
 
         val users = catalog["${FileSystem.KAFKA_CLUSTERS_PREFIX}/local/topics/users"]
         requireNotNull(users)
@@ -54,7 +43,5 @@ internal class CatalogTest {
                 tuple("id", Schema.String.empty),
                 tuple("name", Schema.String.empty)
             )
-
-        job.cancel()
     }
 }

--- a/server/src/test/kotlin/io/typestream/grpc/InteractiveSessionServiceTest.kt
+++ b/server/src/test/kotlin/io/typestream/grpc/InteractiveSessionServiceTest.kt
@@ -32,7 +32,6 @@ import kotlin.test.assertTrue
 
 @Testcontainers
 internal class InteractiveSessionServiceTest {
-    private val logger = KotlinLogging.logger {}
     private val dispatcher = Dispatchers.IO
 
     private lateinit var app: Server

--- a/tools/src/test/resources/simplelogger.properties
+++ b/tools/src/test/resources/simplelogger.properties
@@ -1,1 +1,8 @@
 org.slf4j.simpleLogger.defaultLogLevel=off
+org.slf4j.simpleLogger.log.io.typestream=INFO
+org.slf4j.simpleLogger.log.io.typestream.server.LoggerInterceptor=DEBUG
+org.slf4j.simpleLogger.showLogName=true
+org.slf4j.simpleLogger.showThreadName=false
+org.slf4j.simpleLogger.showDateTime=true
+org.slf4j.simpleLogger.dateTimeFormat=yyyy-MM-dd HH:mm:ss:SSS
+


### PR DESCRIPTION
The main reason behind this feature is that we don't need to watch the filesystem from workers. By introducing a syncronous method to fetch filesystem information, I could also simplify lots of tests