### PR TITLE
chore: speed up seed test

### DIFF
--- a/libs/testing/src/main/kotlin/io/typestream/testing/kafka/KafkaConsumerWrapper.kt
+++ b/libs/testing/src/main/kotlin/io/typestream/testing/kafka/KafkaConsumerWrapper.kt
@@ -2,57 +2,58 @@ package io.typestream.testing.kafka
 
 import io.confluent.kafka.serializers.KafkaAvroDeserializer
 import io.confluent.kafka.serializers.KafkaAvroDeserializerConfig
+import io.github.oshai.kotlinlogging.KotlinLogging
 import org.apache.avro.specific.SpecificRecordBase
 import org.apache.kafka.clients.consumer.ConsumerConfig
 import org.apache.kafka.clients.consumer.ConsumerRecord
 import org.apache.kafka.clients.consumer.ConsumerRecords
 import org.apache.kafka.clients.consumer.KafkaConsumer
 import org.apache.kafka.common.serialization.StringDeserializer
+import org.checkerframework.checker.units.qual.K
 import java.time.Duration
 import java.util.Properties
 import java.util.UUID
 
 class KafkaConsumerWrapper(private val boostrapServers: String, private val schemaRegistryUrl: String) {
-    private fun <K : SpecificRecordBase> consumeRecords(
-        topic: String,
-        expected: Int,
-    ): List<ConsumerRecord<String, K>> {
-        var fetched = 0
-        val recordsToReturn: MutableList<ConsumerRecord<String, K>> = ArrayList()
-        val consumer = KafkaConsumer<String, K>(consumerConfig())
-        consumer.subscribe(listOf(topic))
-        var retries = 0
-        do {
-            val records: ConsumerRecords<String, K> = consumer.poll(Duration.ofMillis(1000))
-            if (!records.isEmpty) {
+    private val logger = KotlinLogging.logger { }
+
+    fun consume(recordsToFetch: List<RecordsExpected>): MutableList<ConsumerRecord<String, SpecificRecordBase>> {
+        val expected = recordsToFetch.associateBy({ it.topic }, { it.expected })
+        val fetched = recordsToFetch.associateBy({ it.topic }, { 0 }).toMutableMap()
+        val recordsToReturn: MutableList<ConsumerRecord<String, SpecificRecordBase>> = ArrayList()
+        KafkaConsumer<String, SpecificRecordBase>(consumerConfig()).use { consumer ->
+            consumer.subscribe(recordsToFetch.map { it.topic })
+            var retries = 0
+            do {
+                logger.debug { "retry: $retries" }
+                val records: ConsumerRecords<String, SpecificRecordBase> = consumer.poll(Duration.ofMillis(1000))
                 for (record in records) {
-                    if (fetched < expected) {
+                    if (fetched[record.topic()]!! < expected[record.topic()]!!) {
                         recordsToReturn.add(record)
-                        fetched++
+                        fetched[record.topic()] = fetched[record.topic()]!! + 1
                     }
                 }
-            }
-        } while ((retries++ < 30) and (fetched < expected))
-        consumer.unsubscribe()
-
-        if (fetched < expected) {
-            throw RuntimeException("could not consume from $topic on time. Fetched: $fetched Expected: $expected")
+                logger.debug { "fetched: $fetched" }
+            } while ((retries++ < 30) and (fetched.values.sum() < expected.values.sum()))
+            consumer.unsubscribe()
         }
+
+        if (fetched.values.sum() < expected.values.sum()) {
+            throw RuntimeException("could not consume on time. Fetched: $fetched Expected: $expected")
+        }
+
         return recordsToReturn
     }
 
-    fun <K : SpecificRecordBase> consume(topic: String, expected: Int): List<K> =
-        consumeRecords<K>(topic, expected).map { it.value() }
-
     private fun consumerConfig(): Properties {
         val consumerProps = Properties()
+        consumerProps[ConsumerConfig.AUTO_OFFSET_RESET_CONFIG] = "earliest"
         consumerProps[ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG] = boostrapServers
+        consumerProps[ConsumerConfig.GROUP_ID_CONFIG] = UUID.randomUUID().toString()
         consumerProps[ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG] = StringDeserializer::class.java
         consumerProps[ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG] = KafkaAvroDeserializer::class.java
-        consumerProps[ConsumerConfig.GROUP_ID_CONFIG] = UUID.randomUUID().toString()
         consumerProps[KafkaAvroDeserializerConfig.SCHEMA_REGISTRY_URL_CONFIG] = schemaRegistryUrl
         consumerProps[KafkaAvroDeserializerConfig.SPECIFIC_AVRO_READER_CONFIG] = true
-        consumerProps[ConsumerConfig.AUTO_OFFSET_RESET_CONFIG] = "earliest"
         return consumerProps
     }
 }

--- a/libs/testing/src/main/kotlin/io/typestream/testing/kafka/KafkaProducerWrapper.kt
+++ b/libs/testing/src/main/kotlin/io/typestream/testing/kafka/KafkaProducerWrapper.kt
@@ -10,10 +10,10 @@ import java.util.Properties
 
 class KafkaProducerWrapper(private val bootstrapServers: String, private val schemaRegistryUrl: String) {
     fun <K, V> produce(records: List<ProducerRecord<K, V>>) {
-        val producer = KafkaProducer<K, V>(producerConfig())
-
-        for (e in records) {
-            producer.send(e).get()
+        KafkaProducer<K, V>(producerConfig()).use {
+            for (e in records) {
+                it.send(e).get()
+            }
         }
     }
 

--- a/libs/testing/src/main/kotlin/io/typestream/testing/kafka/RecordsExpected.kt
+++ b/libs/testing/src/main/kotlin/io/typestream/testing/kafka/RecordsExpected.kt
@@ -1,0 +1,3 @@
+package io.typestream.testing.kafka
+
+data class RecordsExpected(val topic: String, val expected: Int)

--- a/tools/src/main/kotlin/io/typestream/tools/command/StreamPageViews.kt
+++ b/tools/src/main/kotlin/io/typestream/tools/command/StreamPageViews.kt
@@ -1,9 +1,11 @@
 package io.typestream.tools.command
 
+import io.typestream.testing.avro.Author
 import io.typestream.testing.avro.buildBook
 import io.typestream.testing.avro.toProducerRecords
 import io.typestream.testing.kafka.KafkaConsumerWrapper
 import io.typestream.testing.kafka.KafkaProducerWrapper
+import io.typestream.testing.kafka.RecordsExpected
 import io.typestream.tools.KafkaClustersConfig
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.runBlocking
@@ -26,7 +28,12 @@ fun streamPageViews(kafkaClustersConfig: KafkaClustersConfig) = runBlocking {
 
     val kafkaConsumerWrapper = KafkaConsumerWrapper(kafkaConfig.bootstrapServers, kafkaConfig.schemaRegistryUrl)
 
-    val authors = kafkaConsumerWrapper.consume<io.typestream.testing.avro.Author>("authors", 3)
+    val authors = kafkaConsumerWrapper.consume(listOf(("authors" to 3)).map { (topic, expected) ->
+        RecordsExpected(
+            topic,
+            expected
+        )
+    }).filter { it.topic() == "authors" }.map { it.value() as Author }
 
     val emily = authors.find { it.name == "Emily St. John Mandel" } ?: error("Emily not found")
     val olivia = authors.find { it.name == "Octavia E. Butler" } ?: error("Octavia not found")


### PR DESCRIPTION
The test is now more than twice as fast as we fetch all records together. We can introduce more dev friendly method signatures once there's more usage