### PR TITLE
chore: speed up filesystem tests

### DIFF
--- a/server/src/test/kotlin/io/typestream/filesystem/FileSystemTest.kt
+++ b/server/src/test/kotlin/io/typestream/filesystem/FileSystemTest.kt
@@ -12,7 +12,7 @@ import io.typestream.testing.avro.buildAuthor
 import io.typestream.testing.konfig.testKonfig
 import kotlinx.coroutines.Dispatchers
 import org.assertj.core.api.Assertions.assertThat
-import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest
@@ -21,76 +21,27 @@ import org.junit.jupiter.params.provider.MethodSource
 import org.testcontainers.junit.jupiter.Container
 import org.testcontainers.junit.jupiter.Testcontainers
 import java.util.stream.Stream
-import kotlin.test.assertNull
 
 @Testcontainers
 internal class FileSystemTest {
-
-    @Container
-    private val testKafka = RedpandaContainerWrapper()
-
-    private lateinit var fileSystem: FileSystem
-
-    @BeforeEach
-    fun beforeEach() {
-        fileSystem = FileSystem(SourcesConfig(testKonfig(testKafka)), Dispatchers.IO)
-    }
-
-    @Test
-    fun `expands paths correctly`() {
-        fileSystem.use {
-            assertThat(fileSystem.expandPath("dev", "/")).isEqualTo("/dev")
-            assertThat(fileSystem.expandPath("dev/", "/")).isEqualTo("/dev")
-            assertThat(fileSystem.expandPath("kafka", "/dev")).isEqualTo("/dev/kafka")
-            assertThat(fileSystem.expandPath("/dev/kafka", "/")).isEqualTo("/dev/kafka")
-            assertThat(fileSystem.expandPath("/dev/kafka", "/dev")).isEqualTo("/dev/kafka")
-            assertThat(fileSystem.expandPath("", "/")).isEqualTo("/")
-            assertThat(fileSystem.expandPath("..", "/dev")).isEqualTo("/")
-            assertThat(fileSystem.expandPath("..", "/dev/kafka")).isEqualTo("/dev")
-            assertNull(fileSystem.expandPath("dev/whatever", "/"))
-        }
-    }
-
-    @Nested
-    inner class EncodingRules {
-        @Test
-        fun `infers simple encoding`() {
-            fileSystem.use {
-                testKafka.produceRecords("authors", buildAuthor("Octavia E. Butler"))
-
-                fileSystem.refresh()
-
-                val dataCommand = Cat(listOf(Expr.BareWord("/dev/kafka/local/topics/authors")))
-
-                dataCommand.dataStreams.add(author())
-
-                assertThat(fileSystem.inferEncoding(dataCommand)).isEqualTo(Encoding.AVRO)
-            }
-        }
-
-        @Test
-        fun `infers pipeline encoding`() {
-            fileSystem.use {
-                testKafka.produceRecords("authors", buildAuthor("Emily St. John Mandel"))
-
-                fileSystem.refresh()
-
-                val cat = Cat(listOf(Expr.BareWord("/dev/kafka/local/topics/authors")))
-
-                cat.dataStreams.add(author())
-
-                val grep = Grep(listOf(Expr.BareWord("Mandel")))
-
-                val pipeline = Pipeline(listOf(cat, grep))
-
-                assertThat(fileSystem.inferEncoding(pipeline)).isEqualTo(Encoding.AVRO)
-            }
-        }
-    }
-
     companion object {
+        private lateinit var fileSystem: FileSystem
+
+        @Container
+        private val testKafka = RedpandaContainerWrapper()
+
         @JvmStatic
-        fun incompletePaths(): Stream<Arguments> = Stream.of(
+        @BeforeAll
+        fun beforeAll() {
+            fileSystem = FileSystem(SourcesConfig(testKonfig(testKafka)), Dispatchers.IO)
+
+            testKafka.produceRecords("authors", buildAuthor("Octavia E. Butler"))
+
+            fileSystem.refresh()
+        }
+
+        @JvmStatic
+        fun completePathCases(): Stream<Arguments> = Stream.of(
             Arguments.of("d", "/", listOf("dev/")),
             Arguments.of("/d", "/", listOf("/dev/")),
             Arguments.of("ka", "/dev", listOf("kafka/")),
@@ -105,26 +56,55 @@ internal class FileSystemTest {
                 )
             ),
         )
+
+        @JvmStatic
+        fun expandPathCases(): Stream<Arguments> = Stream.of(
+            Arguments.of("dev", "/", "/dev"),
+            Arguments.of("dev/", "/", "/dev"),
+            Arguments.of("kafka", "/dev", "/dev/kafka"),
+            Arguments.of("/dev/kafka", "/", "/dev/kafka"),
+            Arguments.of("/dev/kafka", "/dev", "/dev/kafka"),
+            Arguments.of("", "/", "/"),
+            Arguments.of("..", "/dev", "/"),
+            Arguments.of("..", "/dev/kafka", "/dev"),
+            Arguments.of("dev/whatever", "/", null),
+        )
     }
 
     @ParameterizedTest
-    @MethodSource("incompletePaths")
+    @MethodSource("completePathCases")
     fun `completes correctly`(incompletePath: String, pwd: String, suggestions: List<String>) {
-        fileSystem.use {
-            assertThat(fileSystem.completePath(incompletePath, pwd)).contains(*suggestions.toTypedArray())
-        }
+        assertThat(fileSystem.completePath(incompletePath, pwd)).contains(*suggestions.toTypedArray())
     }
 
-    @Test
-    fun `only completes directories with trailing slash`() {
-        fileSystem.use {
-            testKafka.produceRecords("authors", buildAuthor("Chimamanda Ngozi Adichie"))
+    @ParameterizedTest
+    @MethodSource("expandPathCases")
+    fun `expands paths correctly`(path: String, pwd: String, expected: String?) {
+        assertThat(fileSystem.expandPath(path, pwd)).isEqualTo(expected)
+    }
 
-            fileSystem.refresh()
+    @Nested
+    inner class EncodingRules {
+        @Test
+        fun `infers simple encoding`() {
+            val dataCommand = Cat(listOf(Expr.BareWord("/dev/kafka/local/topics/authors")))
 
-            assertThat(
-                fileSystem.completePath("dev/kafka/local/topics/a", "/")
-            ).contains("dev/kafka/local/topics/authors")
+            dataCommand.dataStreams.add(author())
+
+            assertThat(fileSystem.inferEncoding(dataCommand)).isEqualTo(Encoding.AVRO)
+        }
+
+        @Test
+        fun `infers pipeline encoding`() {
+            val cat = Cat(listOf(Expr.BareWord("/dev/kafka/local/topics/authors")))
+
+            cat.dataStreams.add(author())
+
+            val grep = Grep(listOf(Expr.BareWord("Butler")))
+
+            val pipeline = Pipeline(listOf(cat, grep))
+
+            assertThat(fileSystem.inferEncoding(pipeline)).isEqualTo(Encoding.AVRO)
         }
     }
 }

--- a/server/src/test/kotlin/io/typestream/grpc/InteractiveSessionServiceTest.kt
+++ b/server/src/test/kotlin/io/typestream/grpc/InteractiveSessionServiceTest.kt
@@ -1,6 +1,5 @@
 package io.typestream.grpc
 
-import io.github.oshai.kotlinlogging.KotlinLogging
 import io.grpc.inprocess.InProcessChannelBuilder
 import io.grpc.inprocess.InProcessServerBuilder
 import io.grpc.testing.GrpcCleanupRule

--- a/tools/src/test/kotlin/io/typestream/tools/command/SeedKtTest.kt
+++ b/tools/src/test/kotlin/io/typestream/tools/command/SeedKtTest.kt
@@ -3,8 +3,6 @@ package io.typestream.tools.command
 import io.typestream.testing.RedpandaContainerWrapper
 import io.typestream.testing.avro.Author
 import io.typestream.testing.avro.Book
-import io.typestream.testing.avro.PageView
-import io.typestream.testing.avro.Rating
 import io.typestream.testing.avro.User
 import io.typestream.testing.kafka.AdminClientWrapper
 import io.typestream.testing.kafka.KafkaConsumerWrapper


### PR DESCRIPTION
As per usual, the trick with perf is doing less