### PR TITLE
feat: support basic grep options

### DIFF
--- a/.run/Server.run.xml
+++ b/.run/Server.run.xml
@@ -6,6 +6,7 @@
     <module name="typestream.server.main" />
     <option name="PROGRAM_PARAMETERS" value="$ProjectFileDir$/scripts/dev/server.properties" />
     <shortenClasspath name="NONE" />
+    <option name="VM_PARAMETERS" value="-Dorg.slf4j.simpleLogger.log.io.typestream.server.LoggerInterceptor=DEBUG" />
     <method v="2">
       <option name="Make" enabled="true" />
     </method>

--- a/docs/docs/how-to/filtering.md
+++ b/docs/docs/how-to/filtering.md
@@ -4,30 +4,56 @@ description: Learn how to filter streams using the grep operator.
 
 # Filtering streams
 
-In the true spirit of Unix, `TypeStream` allows you to filter streams using the
-`grep` data operator.
+The purpose of this document is to explain how to use the `grep` operator via
+examples. If you're looking for a formal specification of its usage, refer to
+the [specification](reference/language/operators.md#grep) document.
 
 ## Filtering by content
 
-The simplest way to do filtering is to use the `grep` operator with a string parameter:
+The simplest way to do filtering is to use the `grep` operator with a string
+parameter:
 
-```bash
-cat /dev/kafka/local/topics/books | grep "Station"
+```sh
+grep /dev/kafka/local/topics/books "Station"
 {"id":"9923d491-d421-4c84-9a97-7d1f7bc613a4","title":"Station Eleven","word_count":300,"author_id":"011bb70f-9dd3-4a1e-894c-bf6bb19879f8"}
 ```
 
-Here's this example in action:
+bare words are also supported, meaning that the following is equivalent to the previous example:
 
-![grep](../../../assets/vhs/grep.gif)
+```sh
+grep /dev/kafka/local/topics/books station
+```
+
+Note that the `grep` data operator is case _insensitive_ because it is meant for
+quick searches so it's not the most flexible.
+
+For more complex filtering, you can use the `grep` operator with a predicate
+expression as explained in the rest of this document.
 
 ## Filtering by field
 
-You can also filter by field using the `grep` operator with a field name parameter:
+The `grep` data operator supports predicate expressions. They allow you to
+express more complex filtering conditions. See the
+[reference](reference/language/operators.md#predicate-expressions) for a formal
+specification of its syntax.
 
-```bash
- cat /dev/kafka/local/topics/books | grep [.word_count > 250]
-{"id":"76b47cb7-07cc-4949-a178-2e3acfbbf1f1","title":"The Glass Hotel","word_count":500,"author_id":"743626be-8380-40e9-ab1b-44dfc398cde0"}
+The following example shows how to filter by a specific field:
+
+```sh
+grep /dev/kafka/local/topics/books [.word_count > 250]
+{"id":"76b47cb7-07cc-4949-a178-2e3acfbbf1f1","title":"The Glass Hotel","word_count":500 "author_id":"743626be-8380-40e9-ab1b-44dfc398cde0"}
 {"id":"392ff175-6f93-4228-8620-fba20b6a4f73","title":"Station Eleven","word_count":300,"author_id":"743626be-8380-40e9-ab1b-44dfc398cde0"}
 {"id":"9ba6893e-2980-4316-b9c3-605799a08bde","title":"Sea of Tranquility","word_count":400,"author_id":"743626be-8380-40e9-ab1b-44dfc398cde0"}
 {"id":"a8c6a266-2827-4b87-873a-f1fcf3f9b138","title":"Purple Hibiscus","word_count":300,"author_id":"da68bea8-4a8e-4f96-bc39-25b0b697d94b"}
+```
+
+You can also combine multiple conditions:
+
+```sh
+grep /dev/kafka/local/topics/books [ .word_count == 300 || .title ~= 'the' ]
+{"id":"3734cb2a-6ba3-4227-9e3a-447df83e5818","title":"Station Eleven","word_count":300,"author_id":"9a48dc54-ece4-4be9-ae08-c8c93d6bde5a"}
+{"id":"8dae24e8-20e4-46ef-8465-cf8100b41c75","title":"Parable of the Talents","word_count":200,"author_id":"46fdbf84-b7b1-4dc5-9eb7-f6024fc5725f"}
+{"id":"809c833e-b491-49a9-a0fb-cc0f263238c0","title":"The Glass Hotel","word_count":500,"author_id":"9a48dc54-ece4-4be9-ae08-c8c93d6bde5a"}
+{"id":"c38b7288-ee8c-4708-bc2f-2dc1dff28c2a","title":"Parable of the Sower","word_count":200,"author_id":"46fdbf84-b7b1-4dc5-9eb7-f6024fc5725f"}
+{"id":"6f0c405e-9de4-44cd-a7da-e28462ddcf14","title":"Purple Hibiscus","word_count":300,"author_id":"37d75835-f131-4a7a-99c4-fe9d54703c05"}
 ```

--- a/docs/docs/reference/language/operators.md
+++ b/docs/docs/reference/language/operators.md
@@ -1,0 +1,60 @@
+# Data Operators
+
+The purpose of this document is to spec `TypeStream` data operators.
+
+## Cat
+
+## Cut
+
+## Grep
+
+### Synopsis
+
+`grep [-kv] [<pattern>|*(<predicate>)] [<path>]`
+
+### Description
+
+The `grep` data operator is used to filter in data streams. The default string
+pattern usage filters by "content" (i.e. the whole record) matching each records
+against the pattern.
+
+For more complex filter operations, grep supports predicates expressions. See
+the [predicate expressions](#predicate-expressions) section for more details.
+
+The following options are supported:
+
+- `-k` `--by-key` - filter by key
+- `-v` `--invert-match` - invert the sense of matching, to select non-matching records
+
+#### Predicate expressions
+
+:::note
+
+While in the rest of this document the characters `[` and `]` indicate
+optional parts of a command, here they are part of the syntax and must be
+included in the expression.
+
+:::
+
+`[ .field <operator> <value> ]`
+
+Expressions can be combined with `&&` and `||` operators and grouped with `()`.
+
+Here's the list of supported operators:
+
+- `==`
+  Strict equality operator. The value must be of the same type as the field.
+- `!=`
+  Strict inequality operator. The value must be of the same type as the field.
+- `>`, `>=`, `<`, `<=`
+  Numeric comparison operators. The value must be a number.
+- `~=`
+  "Contains" operator. It matches if the field contains the value. Ignores case.
+
+See the [filtering streams](how-to/filtering.md) how-to document for examples.
+
+## Enrich
+
+## Join
+
+## Wc

--- a/docs/docs/reference/language/shell.md
+++ b/docs/docs/reference/language/shell.md
@@ -1,6 +1,12 @@
 # Shell commands
 
 Since `TypeStream` is heavily inspired by the Unix philosophy, it's only natural
-that it supports lots of shell commands.
+that it supports many shell commands.
 
-TODO
+## Cd
+
+## Ls
+
+## Pwd
+
+## Ps

--- a/docs/docs/reference/language/specs.md
+++ b/docs/docs/reference/language/specs.md
@@ -6,18 +6,24 @@ While `TypeStream` syntax is inspired by
 [bash](https://tiswww.case.edu/php/chet/bash/bashtop.html), feature parity is a
 _non_ goal of the project.
 
-By default, `TypeStream` doesn't need a syntax to specify types. It can infer types
-from context.
+## Keywords
+
+TODO
+
+## Types
+
+By default, `TypeStream` doesn't need a syntax to specify types. It can infer
+types from context.
 
 - String
 - Number
 - List
 - DataStream
 
-## DataStream
+### DataStream
 
-In `TypeStream`, a DataStream is a typed source of data. `TypeStream` always outputs
-structured data (defaulting to encoding data in JSON).
+In `TypeStream`, a DataStream is a typed source of data. `TypeStream` always
+outputs structured data (defaulting to encoding data in JSON).
 
 Let's start from some examples:
 
@@ -37,29 +43,3 @@ $ join users words
 # 1, [users: {name: Foo, age: 42}, words: "first word"]
 # 2, [users: {name: Foo, age: 42}, words: "second word"]
 ```
-
-## Data Operators
-
-### Cat
-
-### Cut
-
-### Grep
-
-Grep commands accepts conditions like:
-
-```sh
-cat /dev/kafka/local/topics/books | grep [ .title == 'Station Eleven' ]
-```
-
-Here's a list of supporter operators:
-
-- `==`
-- `!=`
-- `>`, `>=`
-- `<`, `<=`
-- `in`
-
-### Join
-
-### Wc

--- a/docs/sidebars.js
+++ b/docs/sidebars.js
@@ -48,6 +48,7 @@ const sidebars = {
       items: [
         "reference/glossary",
         "reference/language/specs",
+        "reference/language/operators",
         "reference/language/shell",
         "reference/language/experiments",
       ],

--- a/server/src/main/kotlin/io/typestream/compiler/Interpreter.kt
+++ b/server/src/main/kotlin/io/typestream/compiler/Interpreter.kt
@@ -155,13 +155,13 @@ class Interpreter(private val session: Session) : Statement.Visitor<Unit>, Expr.
 
                     when (command) {
                         is Grep -> errors.addAll(command.predicates.flatMap { it.typeCheck(typeStream) })
-                        is Cut -> command.boundArgs.forEach { key -> checkKey(typeStream, key) }
+                        is Cut -> command.boundArgs.forEach { key -> checkField(typeStream, key) }
                         is Wc -> {
                             // TODO we're parsing options twice.
                             //  To do it once, we need to do it at the end of visitDataCommand
                             val (options, _) = command.parseOptions()
                             if (options.by.isNotBlank()) {
-                                checkKey(typeStream, options.by)
+                                checkField(typeStream, options.by)
                             }
                         }
 
@@ -260,8 +260,8 @@ class Interpreter(private val session: Session) : Statement.Visitor<Unit>, Expr.
     }
 
     //TODO the message has the incorrect path (as it's the resulting type)
-    private fun checkKey(typeStream: DataStream, key: String) {
-        if (!typeStream.hasKey(key)) {
+    private fun checkField(typeStream: DataStream, key: String) {
+        if (!typeStream.hasField(key)) {
             errors.add(
                 """
                     cannot find field '$key' in ${typeStream.path}.

--- a/server/src/main/kotlin/io/typestream/compiler/ast/Grep.kt
+++ b/server/src/main/kotlin/io/typestream/compiler/ast/Grep.kt
@@ -2,37 +2,45 @@ package io.typestream.compiler.ast
 
 import io.typestream.compiler.node.Node
 import io.typestream.graph.Graph
+import io.typestream.option.Option
+import io.typestream.option.parseOptions
 import kotlinx.serialization.Serializable
 
-//TODO add support for key based filtering
 @Serializable
 data class Grep(override val expressions: List<Expr>) : DataCommand() {
+    data class Options(
+        @param:Option(
+            names = ["-v", "--invert-match"],
+            description = "inverts matching pattern"
+        ) val invertMatch: Boolean = false,
+        @param:Option(names = ["-k", "--by-key"], description = "matches key only") val byKey: Boolean = false,
+    )
+
     val predicates = mutableListOf<Predicate>()
 
     override fun resolve(): Graph<Node> {
-        if (predicates.isNotEmpty()) {
-            return Graph(Node.Filter(toString(), predicates.stream().reduce(Predicate::and).get()))
+        val (options, args) = parseOptions<Options>(boundArgs)
+
+        var predicate =
+            if (predicates.isNotEmpty()) predicates.reduce(Predicate::and) else Predicate.matches(args.first())
+
+        if (options.invertMatch) {
+            predicate = predicate.not()
         }
 
-        val predicate = Predicate.matches(boundArgs.first())
-
         return when (dataStreams.size) {
-            0 -> Graph(Node.Filter(toString(), predicate))
+            0 -> Graph(Node.Filter(toString(), options.byKey, predicate))
 
             1 -> {
-                val streamSourceNode: Graph<Node> = Graph(
+                Graph<Node>(
                     Node.StreamSource(
-                        toString(),
-                        dataStreams.first(),
+                        toString(), dataStreams.first(),
                         encoding ?: error("cannot resolve grep command: unbound encoding")
                     )
-                )
-
-                streamSourceNode.addChild(Graph(Node.Filter(toString(), predicate)))
-                streamSourceNode
+                ).also { it.addChild(Graph(Node.Filter(toString(), options.byKey, predicate))) }
             }
 
-            else -> throw IllegalArgumentException("invalid number of arguments")
+            else -> throw IllegalArgumentException("cat does not support multiple data streams")
         }
     }
 }

--- a/server/src/main/kotlin/io/typestream/compiler/ast/Predicate.kt
+++ b/server/src/main/kotlin/io/typestream/compiler/ast/Predicate.kt
@@ -37,7 +37,7 @@ sealed interface Predicate {
     }
 
     private data class Equals(val key: String, val value: Schema) : Predicate {
-        override fun matches(dataStream: DataStream) = dataStream[key] == value
+        override fun matches(dataStream: DataStream) = dataStream[key].compareTo(value) == 0
     }
 
     private data class Matches(val pattern: String) : Predicate {
@@ -68,7 +68,7 @@ sealed interface Predicate {
     }
 
     private fun opTypeCheck(dataStream: DataStream, key: String, value: Schema) = buildList {
-        if (!dataStream.hasKey(key)) {
+        if (!dataStream.hasField(key)) {
             add("cannot find field '$key' in ${dataStream.path}.\nYou can use 'file ${dataStream.path}' to check available fields")
         } else {
             val schema = dataStream[key]

--- a/server/src/main/kotlin/io/typestream/compiler/kafka/KafkaStreamSource.kt
+++ b/server/src/main/kotlin/io/typestream/compiler/kafka/KafkaStreamSource.kt
@@ -76,7 +76,11 @@ data class KafkaStreamSource(val node: Node.StreamSource, private val streamsBui
     }
 
     fun filter(filter: Node.Filter) {
-        stream = stream.filter { _, v -> filter.predicate.matches(v) }
+        stream = if (filter.byKey) {
+            stream.filter { k, _ -> filter.predicate.matches(k) }
+        } else {
+            stream.filter { _, v -> filter.predicate.matches(v) }
+        }
     }
 
     fun group(group: Node.Group) {

--- a/server/src/main/kotlin/io/typestream/compiler/lexer/LexError.kt
+++ b/server/src/main/kotlin/io/typestream/compiler/lexer/LexError.kt
@@ -1,3 +1,0 @@
-package io.typestream.compiler.lexer
-
-data class LexError(val line: Int, val column: Int)

--- a/server/src/main/kotlin/io/typestream/compiler/node/Node.kt
+++ b/server/src/main/kotlin/io/typestream/compiler/node/Node.kt
@@ -13,7 +13,7 @@ sealed interface Node {
     data class Count(override val id: String) : Node
 
     @Serializable
-    data class Filter(override val id: String, val predicate: Predicate) : Node
+    data class Filter(override val id: String, val byKey: Boolean, val predicate: Predicate) : Node
 
     @Serializable
     data class Group(override val id: String, val keyMapper: (KeyValue) -> DataStream) : Node

--- a/server/src/main/kotlin/io/typestream/compiler/types/DataStream.kt
+++ b/server/src/main/kotlin/io/typestream/compiler/types/DataStream.kt
@@ -22,7 +22,7 @@ data class DataStream(val path: String, val schema: Schema) : Value {
 
     operator fun get(key: String) = schema.selectOne(key) ?: Schema.Struct.empty()
 
-    fun hasKey(key: String): Boolean {
+    fun hasField(key: String): Boolean {
         require(schema is Schema.Struct) { "schema is not a struct" }
 
         return schema.selectOne(key) != null

--- a/server/src/main/kotlin/io/typestream/compiler/types/schema/Schema.kt
+++ b/server/src/main/kotlin/io/typestream/compiler/types/schema/Schema.kt
@@ -101,7 +101,7 @@ sealed interface Schema {
             is List -> value.any { it.matches(pattern) }
             is Long -> value.toString().contains(pattern)
             is Named -> value.matches(pattern)
-            is String -> value.contains(pattern)
+            is String -> value.contains(pattern, true)
             is Struct -> value.any { it.matches(pattern) }
             is UUID -> value.toString().contains(pattern)
         }

--- a/server/src/main/kotlin/io/typestream/compiler/types/value/ValueExt.kt
+++ b/server/src/main/kotlin/io/typestream/compiler/types/value/ValueExt.kt
@@ -23,35 +23,40 @@ fun Value.Companion.fromBinary(left: Value, operator: TokenType, right: Value): 
     }
 
     if (left is Value.FieldAccess && right is Value.String) {
-        return when (operator) {
-            EQUAL_EQUAL -> Value.Predicate(Predicate.equals(left.value, Schema.String(right.value)))
-            BANG_EQUAL -> Value.Predicate(Predicate.equals(left.value, Schema.String(right.value)).not())
-            ALMOST_EQUAL -> Value.Predicate(Predicate.almostEquals(left.value, Schema.String(right.value)))
+        return fieldAccessAndString(left, operator, right)
+    }
 
-            else -> error("$operator not supported")
-        }
+    if (left is Value.String && right is Value.FieldAccess) {
+        return fieldAccessAndString(right, operator, left)
     }
 
     if (left is Value.FieldAccess && right is Value.Number) {
-        return when (operator) {
-            EQUAL_EQUAL -> Value.Predicate(Predicate.equals(left.value, Schema.Long(right.value.toLong())))
-            BANG_EQUAL -> Value.Predicate(
-                Predicate.equals(left.value, Schema.Long(right.value.toLong())).not()
-            )
+        return fieldAccessAndNumber(left, operator, right)
+    }
 
-            GREATER -> Value.Predicate(Predicate.greaterThan(left.value, Schema.Long(right.value.toLong())))
-            GREATER_EQUAL -> Value.Predicate(
-                Predicate.greaterOrEqualThan(left.value, Schema.Long(right.value.toLong()))
-            )
-
-            LESS -> Value.Predicate(Predicate.lessThan(left.value, Schema.Long(right.value.toLong())))
-            LESS_EQUAL -> Value.Predicate(
-                Predicate.lessOrEqualThan(left.value, Schema.Long(right.value.toLong()))
-            )
-
-            else -> error("$operator not supported")
-        }
+    if (left is Value.Number && right is Value.FieldAccess) {
+        return fieldAccessAndNumber(right, operator, left)
     }
 
     error("cannot apply $operator to $left and $right")
 }
+
+private fun fieldAccessAndString(left: Value.FieldAccess, operator: TokenType, right: Value.String) = when (operator) {
+    EQUAL_EQUAL -> Value.Predicate(Predicate.equals(left.value, Schema.String(right.value)))
+    BANG_EQUAL -> Value.Predicate(Predicate.equals(left.value, Schema.String(right.value)).not())
+    ALMOST_EQUAL -> Value.Predicate(Predicate.almostEquals(left.value, Schema.String(right.value)))
+
+    else -> error("$operator not supported")
+}
+
+private fun fieldAccessAndNumber(left: Value.FieldAccess, operator: TokenType, right: Value.Number) = when (operator) {
+    BANG_EQUAL -> Value.Predicate(Predicate.equals(left.value, Schema.Long(right.value.toLong())).not())
+    EQUAL_EQUAL -> Value.Predicate(Predicate.equals(left.value, Schema.Long(right.value.toLong())))
+    GREATER -> Value.Predicate(Predicate.greaterThan(left.value, Schema.Long(right.value.toLong())))
+    GREATER_EQUAL -> Value.Predicate(Predicate.greaterOrEqualThan(left.value, Schema.Long(right.value.toLong())))
+    LESS -> Value.Predicate(Predicate.lessThan(left.value, Schema.Long(right.value.toLong())))
+    LESS_EQUAL -> Value.Predicate(Predicate.lessOrEqualThan(left.value, Schema.Long(right.value.toLong())))
+
+    else -> error("$operator not supported")
+}
+

--- a/server/src/main/kotlin/io/typestream/graph/Graph.kt
+++ b/server/src/main/kotlin/io/typestream/graph/Graph.kt
@@ -4,20 +4,9 @@ import kotlinx.serialization.Serializable
 import java.util.function.Predicate
 
 @Serializable
-data class Graph<K>(val ref: K) {
-    val children = mutableSetOf<Graph<K>>()
-
+data class Graph<K>(val ref: K, val children: MutableSet<Graph<K>> = mutableSetOf()) {
     fun addChild(child: Graph<K>) {
         children.add(child)
-    }
-
-    private fun print(node: Graph<K> = this, indent: Int = 1): String = buildString {
-        append(node)
-        append("\n")
-        for (child in node.children) {
-            append("\t".repeat(indent))
-            append(print(child, indent + 1))
-        }
     }
 
     fun walk(visitor: (Graph<K>) -> Unit) {

--- a/server/src/test/kotlin/io/typestream/compiler/ProgramTest.kt
+++ b/server/src/test/kotlin/io/typestream/compiler/ProgramTest.kt
@@ -50,8 +50,7 @@ internal class ProgramTest {
                 )
             )
 
-            assertThat(program.runtime()).extracting("name", "type")
-                .containsExactly("local", KAFKA)
+            assertThat(program.runtime()).extracting("name", "type").containsExactly("local", KAFKA)
         }
 
         @Test

--- a/server/src/test/kotlin/io/typestream/compiler/ast/PredicateTest.kt
+++ b/server/src/test/kotlin/io/typestream/compiler/ast/PredicateTest.kt
@@ -2,16 +2,84 @@ package io.typestream.compiler.ast
 
 import io.typestream.compiler.types.schema.Schema
 import io.typestream.helpers.book
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
-import kotlin.test.assertTrue
 
 
 internal class PredicateTest {
-    @Test
-    fun `matches by equality`() {
-        val predicate = Predicate.equals("title", Schema.String("Station Eleven"))
-        val dataStream = book(title = "Station Eleven")
+    val books = listOf(
+        book(title = "Station Eleven", wordCount = 300),
+        book(title = "Kindred", wordCount = 400),
+        book(title = "Parable of the Sower", wordCount = 250),
+        book(title = "The Glass Hotel", wordCount = 300),
+    )
 
-        assertTrue(predicate.matches(dataStream))
+    @Nested
+    inner class Equals {
+
+        @Test
+        fun `matches string`() {
+            val predicate = Predicate.equals("title", Schema.String("Station Eleven"))
+
+            val filtered = books.filter { predicate.matches(it) }
+
+            assertThat(filtered).hasSize(1)
+            assertThat(filtered.first()["title"]).isEqualTo(Schema.String("Station Eleven"))
+        }
+
+        @Test
+        fun `matches number equality`() {
+            val predicate = Predicate.equals("word_count", Schema.Long(300))
+
+            val filtered = books.filter { predicate.matches(it) }
+
+            assertThat(filtered).hasSize(2)
+            assertThat(filtered.map { it["title"] }).containsExactlyInAnyOrder(
+                Schema.String("Station Eleven"),
+                Schema.String("The Glass Hotel"),
+            )
+        }
+
+        @Test
+        fun `matches strings inequality`() {
+            val predicate = Predicate.equals("title", Schema.String("Station Eleven")).not()
+
+            val filtered = books.filter { predicate.matches(it) }
+
+            assertThat(filtered).hasSize(3)
+            assertThat(filtered.map { it["title"] }).containsExactlyInAnyOrder(
+                Schema.String("Kindred"),
+                Schema.String("Parable of the Sower"),
+                Schema.String("The Glass Hotel"),
+            )
+        }
+    }
+
+    @Nested
+    inner class Matches {
+        @Test
+        fun `matches strings`() {
+            val predicate = Predicate.matches("hotel")
+
+            val filtered = books.filter { predicate.matches(it) }
+
+            assertThat(filtered).hasSize(1)
+            assertThat(filtered.first()["title"]).isEqualTo(Schema.String("The Glass Hotel"))
+        }
+
+        @Test
+        fun `negates strings match`() {
+            val predicate = Predicate.matches("hotel").not()
+
+            val filtered = books.filter { predicate.matches(it) }
+
+            assertThat(filtered).hasSize(3)
+            assertThat(filtered.map { it["title"] }).containsExactlyInAnyOrder(
+                Schema.String("Station Eleven"),
+                Schema.String("Kindred"),
+                Schema.String("Parable of the Sower"),
+            )
+        }
     }
 }

--- a/server/src/test/kotlin/io/typestream/compiler/parser/ParserTest.kt
+++ b/server/src/test/kotlin/io/typestream/compiler/parser/ParserTest.kt
@@ -69,7 +69,6 @@ internal class ParserTest {
         assertThat(command.expressions).isEqualTo(listOf(Expr.BareWord("topic")))
     }
 
-
     // "Sentinel" test to make sure we synchronize correctly inside quotes
     @Test
     fun `parses a quote`() {
@@ -340,8 +339,7 @@ internal class ParserTest {
             val parser = Parser("cat \"books_#{\$foo}\"")
 
             val statements = parser.parse()
-            assertThat(parser.errors)
-                .hasSize(0)
+            assertThat(parser.errors).hasSize(0)
             assertThat(statements).hasSize(1)
 
             assertThat(statements[0]).isInstanceOf(Pipeline::class.java)

--- a/server/src/test/kotlin/io/typestream/compiler/types/value/ValueTest.kt
+++ b/server/src/test/kotlin/io/typestream/compiler/types/value/ValueTest.kt
@@ -8,55 +8,74 @@ import io.typestream.compiler.lexer.TokenType.OR
 import io.typestream.compiler.types.Value
 import io.typestream.compiler.types.schema.Schema
 import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 
 
-class ValueTest {
+internal class ValueTest {
+    @Nested
+    inner class FromBinary {
+        @Test
+        fun `handles grouped conditions`() {
+            assertThat(
+                Value.fromBinary(
+                    Value.Predicate(Predicate.equals("title", Schema.String("Station Eleven"))),
+                    OR,
+                    Value.Predicate(Predicate.equals("title", Schema.String("Kindred")))
+                ).value
+            ).isEqualTo(
+                Predicate.equals("title", Schema.String("Station Eleven"))
+                    .or(Predicate.equals("title", Schema.String("Kindred")))
+            )
+        }
 
-    @Test
-    fun `handles grouped conditions`() {
-        assertThat(
-            Value.fromBinary(
-                Value.Predicate(Predicate.equals("title", Schema.String("Station Eleven"))),
-                OR,
-                Value.Predicate(Predicate.equals("title", Schema.String("Kindred")))
-            ).value
-        ).isEqualTo(
-            Predicate.equals("title", Schema.String("Station Eleven"))
-                .or(Predicate.equals("title", Schema.String("Kindred")))
-        )
-    }
+        @Test
+        fun `handles simple condition`() {
+            assertThat(
+                Value.fromBinary(
+                    Value.FieldAccess("title"),
+                    EQUAL_EQUAL,
+                    Value.String("Station Eleven")
+                ).value
+            ).isEqualTo(Predicate.equals("title", Schema.String("Station Eleven")))
 
-    @Test
-    fun `handles simple condition`() {
-        assertThat(
-            Value.fromBinary(
-                Value.FieldAccess("title"),
-                EQUAL_EQUAL,
-                Value.String("Station Eleven")
-            ).value
-        ).isEqualTo(Predicate.equals("title", Schema.String("Station Eleven")))
-    }
+            assertThat(
+                Value.fromBinary(
+                    Value.String("Station Eleven"),
+                    EQUAL_EQUAL,
+                    Value.FieldAccess("title"),
+                ).value
+            ).isEqualTo(Predicate.equals("title", Schema.String("Station Eleven")))
+        }
 
-    @Test
-    fun `handles simple condition with not`() {
-        assertThat(
-            Value.fromBinary(
-                Value.FieldAccess("title"),
-                BANG_EQUAL,
-                Value.String("Station Eleven")
-            ).value
-        ).isEqualTo(Predicate.equals("title", Schema.String("Station Eleven")).not())
-    }
+        @Test
+        fun `handles simple not condition`() {
+            assertThat(
+                Value.fromBinary(
+                    Value.FieldAccess("title"),
+                    BANG_EQUAL,
+                    Value.String("Station Eleven")
+                ).value
+            ).isEqualTo(Predicate.equals("title", Schema.String("Station Eleven")).not())
+        }
 
-    @Test
-    fun `handles number condition`() {
-        assertThat(
-            Value.fromBinary(
-                Value.FieldAccess("year"),
-                GREATER,
-                Value.Number(2010.0)
-            ).value
-        ).isEqualTo(Predicate.greaterThan("year", Schema.Long(2010)))
+        @Test
+        fun `handles number condition`() {
+            assertThat(
+                Value.fromBinary(
+                    Value.FieldAccess("year"),
+                    GREATER,
+                    Value.Number(2010.0)
+                ).value
+            ).isEqualTo(Predicate.greaterThan("year", Schema.Long(2010)))
+
+            assertThat(
+                Value.fromBinary(
+                    Value.Number(2010.0),
+                    GREATER,
+                    Value.FieldAccess("year"),
+                ).value
+            ).isEqualTo(Predicate.greaterThan("year", Schema.Long(2010)))
+        }
     }
 }

--- a/server/src/test/kotlin/io/typestream/helpers/DataStreamHelpers.kt
+++ b/server/src/test/kotlin/io/typestream/helpers/DataStreamHelpers.kt
@@ -15,7 +15,14 @@ fun author(
 fun book(
     id: Schema.UUID = Schema.UUID(UUID.randomUUID()),
     title: String,
+    wordCount: Int = 42,
 ) = DataStream(
     "/dev/kafka/local/topics/books",
-    Schema.Struct(listOf(Schema.Named("id", id), Schema.Named("title", Schema.String(title))))
+    Schema.Struct(
+        listOf(
+            Schema.Named("id", id),
+            Schema.Named("title", Schema.String(title)),
+            Schema.Named("word_count", Schema.Int(wordCount))
+        )
+    )
 )


### PR DESCRIPTION
Adding options to grep was a bit of an excuse to reorg docs and tests so that we can have finally document all operators before proceeding further