### PR TITLE
feat: show deployment artifacts by default

### DIFF
--- a/cli/cmd/k8s/create.go
+++ b/cli/cmd/k8s/create.go
@@ -15,7 +15,7 @@ var createCmd = &cobra.Command{
 	Short: "Creates a k8s TypeStream server",
 	Run: func(cmd *cobra.Command, args []string) {
 		log.Info("🚀 creating TypeStream server")
-		runner := k8s.NewRunner()
+		runner := k8s.NewRunner(Namespace)
 
 		err := runner.Apply(redpanda)
 		if err != nil {

--- a/cli/cmd/k8s/k8s.go
+++ b/cli/cmd/k8s/k8s.go
@@ -1,14 +1,28 @@
 package k8s
 
 import (
+	"fmt"
+
 	"github.com/spf13/cobra"
+	"github.com/typestreamio/typestream/cli/pkg/k8s"
 )
+
+var Namespace string
 
 var k8sCmd = &cobra.Command{
 	Use:   "k8s",
 	Short: "Manage a kubernetes TypeStream server",
+	Run: func(cmd *cobra.Command, args []string) {
+		runner := k8s.NewRunner(Namespace)
+
+		fmt.Println(runner.Show())
+	},
 }
 
 func NewCommand() *cobra.Command {
 	return k8sCmd
+}
+
+func init() {
+	k8sCmd.PersistentFlags().StringVarP(&Namespace, "namespace", "n", "typestream", "kubernetes namespace to use")
 }

--- a/cli/cmd/k8s/seed.go
+++ b/cli/cmd/k8s/seed.go
@@ -12,7 +12,7 @@ var seedCmd = &cobra.Command{
 	Short: "Seeds the local TypeStream server with some data",
 	Run: func(cmd *cobra.Command, args []string) {
 		log.Info("🚀 starting seeding process")
-		runner := k8s.NewRunner()
+		runner := k8s.NewRunner(Namespace)
 
 		err := runner.ApplySeeder()
 		if err != nil {

--- a/cli/pkg/k8s/seeder.yaml.tmpl
+++ b/cli/pkg/k8s/seeder.yaml.tmpl
@@ -2,7 +2,7 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: seeder
-  namespace: typestream
+  namespace: {{.Namespace}}
 spec:
   template:
     spec:

--- a/cli/pkg/k8s/typestream.yaml.tmpl
+++ b/cli/pkg/k8s/typestream.yaml.tmpl
@@ -1,11 +1,13 @@
+{{if  ne .Namespace "default" }}
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: typestream
+  name: {{.Namespace}}
 spec: {}
 status: {}
 
 ---
+{{end -}}
 
 apiVersion: v1
 kind: ServiceAccount
@@ -18,7 +20,7 @@ metadata:
 kind: Role
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  namespace: typestream
+  namespace: {{.Namespace}}
   name: typestream-service-role
 rules:
 - apiGroups: [""]
@@ -35,7 +37,7 @@ kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: typestream-service-role-binding
-  namespace: typestream
+  namespace: {{.Namespace}}
 subjects:
 - kind: ServiceAccount
   name: typestream-service-account
@@ -50,7 +52,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: server-config
-  namespace: typestream
+  namespace: {{.Namespace}}
 data:
   server.properties: |-
     grpc.port=4242
@@ -65,7 +67,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: server
-  namespace: typestream
+  namespace: {{.Namespace}}
 spec:
   replicas: 1
   selector:
@@ -102,7 +104,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: server
-  namespace: typestream
+  namespace: {{.Namespace}}
 spec:
   ports:
     - name: "4242"

--- a/libs/konfig/src/test/kotlin/io/typestream/konfig/KonfigSourceMapTest.kt
+++ b/libs/konfig/src/test/kotlin/io/typestream/konfig/KonfigSourceMapTest.kt
@@ -13,15 +13,27 @@ internal class KonfigSourceMapTest {
     data class ServersConfig(val servers: Map<String, ServerConfig>)
 
     @Test
-    fun `can load a simple config`() {
-        class App(konfig: io.typestream.konfig.Konfig) {
+    fun `loads a simple map config`() {
+        class App(konfig: Konfig) {
             val serversConfig by konfig.inject<ServersConfig>()
         }
 
-        val konfig = io.typestream.konfig.Konfig(FileInputStream("src/test/resources/map.properties"))
+        val konfig = Konfig(FileInputStream("src/test/resources/map.properties"))
         val app = App(konfig)
 
         assertThat(app.serversConfig.servers["local"]).extracting("host", "port").containsExactly("localhost", 4242)
         assertThat(app.serversConfig.servers["remote"]).extracting("host", "port").containsExactly("example.com", 2424)
+    }
+
+    @Test
+    fun `loads empty map config`() {
+        class App(konfig: Konfig) {
+            val serversConfig by konfig.inject<ServersConfig>()
+        }
+
+        val konfig = Konfig("".byteInputStream())
+        val app = App(konfig)
+
+        assertThat(app.serversConfig.servers).isEmpty()
     }
 }

--- a/libs/konfig/src/test/kotlin/io/typestream/konfig/KonfigSourceTest.kt
+++ b/libs/konfig/src/test/kotlin/io/typestream/konfig/KonfigSourceTest.kt
@@ -19,40 +19,53 @@ internal class KonfigSourceTest {
     data class NestedConfig(val db: DbConfig, val server: ServerConfig)
 
     @Test
-    fun `can load a simple config`() {
-        class App(konfig: io.typestream.konfig.Konfig) {
+    fun `loads a simple config`() {
+        class App(konfig: Konfig) {
             val serverConfig by konfig.inject<ServerConfig>()
         }
 
-        val konfig = io.typestream.konfig.Konfig(FileInputStream("src/test/resources/application.properties"))
+        val konfig = Konfig(FileInputStream("src/test/resources/application.properties"))
         val app = App(konfig)
 
         assertThat(app.serverConfig).extracting("host", "port").containsExactly("localhost", 4242)
     }
 
     @Test
-    fun `can load a simple config without prefix`() {
-        class App(konfig: io.typestream.konfig.Konfig) {
+    fun `loads a simple config without prefix`() {
+        class App(konfig: Konfig) {
             val config by konfig.inject<Config>()
         }
 
-        val konfig = io.typestream.konfig.Konfig(FileInputStream("src/test/resources/application.properties"))
+        val konfig = Konfig(FileInputStream("src/test/resources/application.properties"))
         val app = App(konfig)
 
         assertThat(app.config).extracting("serverHost", "serverPort").containsExactly("localhost", 4242)
     }
 
     @Test
-    fun `can load a nested config`() {
-        class App(konfig: io.typestream.konfig.Konfig) {
+    fun `loads a nested config`() {
+        class App(konfig: Konfig) {
             val config by konfig.inject<NestedConfig>()
         }
 
-        val konfig = io.typestream.konfig.Konfig(FileInputStream("src/test/resources/application.properties"))
+        val konfig = Konfig(FileInputStream("src/test/resources/application.properties"))
         val app = App(konfig)
 
-        assertThat(app.config).extracting("db.endpoint", "server.host", "server.port")
+        assertThat(app.config)
+            .extracting("db.endpoint", "server.host", "server.port")
             .containsExactly("http://db.local:5432", "localhost", 4242)
+    }
+
+    @Test
+    fun `ignores comments`() {
+        class App(konfig: Konfig) {
+            val config by konfig.inject<ServerConfig>()
+        }
+
+        val konfig = Konfig(FileInputStream("src/test/resources/comments.properties"))
+        val app = App(konfig)
+
+        assertThat(app.config).extracting("host", "port").containsExactly("localhost", 4242)
     }
 
 }

--- a/libs/konfig/src/test/resources/comments.properties
+++ b/libs/konfig/src/test/resources/comments.properties
@@ -1,0 +1,3 @@
+# comment
+server.host=localhost
+server.port=4242


### PR DESCRIPTION
Not documenting the feature yet because I'm unsure how to handle the server.properties configuration. On the other hand, there's immediate value for some users if they can access the k8s config on their own