### PR TITLE
build: fix gradle 9.0 warning

### DIFF
--- a/buildSrc/src/main/kotlin/typestream.kotlin-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/typestream.kotlin-conventions.gradle.kts
@@ -27,7 +27,8 @@ dependencies {
 
     testImplementation(kotlin("test"))
     testImplementation("org.assertj:assertj-core:3.24.2")
-    testImplementation("org.junit.jupiter:junit-jupiter:5.10.0")
+    testImplementation("org.junit.jupiter:junit-jupiter:5.10.1")
+    testRuntimeOnly("org.junit.platform:junit-platform-launcher")
     testImplementation("nz.lae.stacksrc:stacksrc-junit5:0.6.0")
     testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.7.3")
     testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test-jvm:1.7.3")


### PR DESCRIPTION
See https://docs.gradle.org/8.5/userguide/upgrading_version_8.html#test_framework_implementation_dependencies