### PR TITLE
fix: mount k8s deployment so the server can find it

### DIFF
--- a/cli/pkg/k8s/seeder.yaml.tmpl
+++ b/cli/pkg/k8s/seeder.yaml.tmpl
@@ -12,5 +12,12 @@ spec:
           imagePullPolicy: Always
           name: seed
           args: ["seed"]
+          volumeMounts:
+          - name: config-volume
+            mountPath: /config
       restartPolicy: Never
+      volumes:
+        - name: config-volume
+          configMap:
+            name: server-config
   backoffLimit: 4

--- a/cli/pkg/k8s/typestream.yaml.tmpl
+++ b/cli/pkg/k8s/typestream.yaml.tmpl
@@ -98,13 +98,13 @@ spec:
               memory: "2048Mi"
           volumeMounts:
             - name: config-volume
-              mountPath: /etc/typestream
+              mountPath: /config
       restartPolicy: Always
+      volumes:
+        - name: config-volume
+          configMap:
+            name: server-config
 status: {}
-volumes:
-- name: config-volume
-  configMap:
-    name: server-config
 ---
 
 apiVersion: v1

--- a/config/build.gradle.kts
+++ b/config/build.gradle.kts
@@ -5,7 +5,6 @@ plugins {
 dependencies {
     implementation(libs.test.containers.redpanda)
     implementation(libs.bundles.sf4j)
+    implementation(libs.mockk)
     implementation("net.peanuuutz.tomlkt:tomlkt:0.3.7")
-
-    testImplementation(libs.mockk)
 }

--- a/config/src/main/kotlin/io/typestream/config/Config.kt
+++ b/config/src/main/kotlin/io/typestream/config/Config.kt
@@ -47,6 +47,16 @@ data class Config(
             } catch (_: Exception) {
             }
 
+            if (kubernetesMode) {
+                logger.info { "copy config from /config into /etc/typestream" }
+                val configFile = Paths.get("/config", "typestream.toml").toFile()
+                val systemConfigFile = Paths.get(systemConfigPath, "typestream.toml").toFile()
+
+                if (configFile.exists()) {
+                    configFile.copyTo(systemConfigFile, true)
+                }
+            }
+
             val envFile = SystemEnv["TYPESTREAM_CONFIG"]
 
             val configFilePath: String = if (envFile != null) {

--- a/scripts/dev/build-images.sh
+++ b/scripts/dev/build-images.sh
@@ -3,5 +3,13 @@
 set -euo pipefail
 IFS=$'\n\t'
 
-gradlew -Pversion=beta -Djib.to.image=localhost:5000/typestream/server:beta :server:jibDockerBuild
-gradlew -Pversion=beta -Djib.to.image=localhost:5000/typestream/tools-seeder:beta :tools:jibDockerBuild
+
+#!/usr/bin/env bash
+
+set -euo pipefail
+IFS=$'\n\t'
+
+PLATFORM=${PLATFORM:-linux/amd64}
+
+gradlew -Pversion=beta -Djib.from.platforms=$PLATFORM -Djib.to.image=localhost:5000/typestream/server:beta :server:jibDockerBuild
+gradlew -Pversion=beta -Djib.from.platforms=$PLATFORM -Djib.to.image=localhost:5000/typestream/tools-seeder:beta :tools:jibDockerBuild


### PR DESCRIPTION
I'm not very happy about mounting in a place and have the server copy the files into the system config place. But I honestly can't find a simple way to mount configs into a container (in a r/w directory). As this may just be my ignorance, it may also change soon