### PR TITLE
chore: add flake

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1713725259,
+        "narHash": "sha256-9ZR/Rbx5/Z/JZf5ehVNMoz/s5xjpP0a22tL6qNvLt5E=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "a5e4bbcb4780c63c79c87d29ea409abf097de3f7",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-23.11",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,45 @@
+{
+  # Adapted from: https://github.com/the-nix-way/dev-templates/blob/main/kotlin/flake.nix
+  description = "A Nix-flake-based Kotlin development environment";
+
+  inputs = { nixpkgs.url = "github:NixOS/nixpkgs/nixos-23.11"; };
+
+  outputs = { self, nixpkgs }:
+    let
+      javaVersion = 20;
+      # Some overlay to inject your dependencies (pkgs.jdk, pkgs.gradle, pkgs.kotlin) should be defined
+      overlays = [
+        (final: prev: rec {
+          jdk = prev."jdk${toString javaVersion}";
+          gradle = prev.gradle.override { java = jdk; };
+          kotlin = prev.kotlin.override { jre = jdk; };
+        })
+      ];
+      supportedSystems =
+        [ "x86_64-linux" "aarch64-linux" "x86_64-darwin" "aarch64-darwin" ];
+      forEachSupportedSystem = f:
+        nixpkgs.lib.genAttrs supportedSystems
+        (system: f { pkgs = import nixpkgs { inherit system; }; });
+    in {
+      devShells = forEachSupportedSystem ({ pkgs }: {
+        # https://ryantm.github.io/nixpkgs/builders/special/fhs-environments/#sec-fhs-environments
+        # WARNING! As I understand, with this configuration your shell will be running in a namespace.
+        # It isolates the filesystem (or at least a part of the filesystem) to behave as a standard
+        # FHS system. gradlew should work normally, thus handling all your dependencies by itself.
+        # With this configuration, your only required dependency is the jdk17.
+        # Thus it is not a packaging flake, but rather a flake to enable development for your tool.
+        default = (pkgs.buildFHSUserEnv {
+          name = "java-dev-env";
+          targetPkgs = pkgs:
+            with pkgs; [
+              jdk17
+              # Gradle for building containers
+              gradle
+              # For the cli
+              docker-compose
+            ];
+          runScript = "bash";
+        }).env;
+      });
+    };
+}


### PR DESCRIPTION
# PR: Add Flake for Development Environment in NixOS

## Description
This PR introduces a flake to facilitate development within a NixOS environment.

To utilize this enhancement, ensure you have Nix installed with the flake feature enabled. Detailed instructions can be found [here](https://nixos.wiki/wiki/Flakes).

Once installed, navigate to the root of the project and execute `nix develop`. This command will drop you into a new shell equipped with the necessary Java dependency. I encountered no issues when following the command described in the [contributing guide](https://github.com/typestreamio/typestream/blob/5093884e94868aacf3320cc0e34e4d0962cfcdd1/CONTRIBUTING.md#building-and-running-typestream).

Additionally, this PR includes a modification to use `gradle` instead of `gradlew` in the [build-images.sh](https://github.com/typestreamio/typestream/compare/main...adfaure:typestream:main#diff-359054bb4db0a6508b4b4773814188fa298764c156ef879786e5cb7f93ea147d) script, as `gradlew` was not accessible in my path.
