### PR TITLE
build: use absolute path for gradlew

### DIFF
--- a/scripts/dev/build-images.sh
+++ b/scripts/dev/build-images.sh
@@ -3,13 +3,9 @@
 set -euo pipefail
 IFS=$'\n\t'
 
-
-#!/usr/bin/env bash
-
-set -euo pipefail
-IFS=$'\n\t'
-
 PLATFORM=${PLATFORM:-linux/amd64}
 
-gradlew -Pversion=beta -Djib.from.platforms=$PLATFORM -Djib.to.image=localhost:5000/typestream/server:beta :server:jibDockerBuild
-gradlew -Pversion=beta -Djib.from.platforms=$PLATFORM -Djib.to.image=localhost:5000/typestream/tools-seeder:beta :tools:jibDockerBuild
+script_dir=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+
+"$script_dir"/../../gradlew -Pversion=beta -Djib.from.platforms="$PLATFORM" -Djib.to.image=localhost:5000/typestream/server:beta :server:jibDockerBuild
+"$script_dir"/../../gradlew -Pversion=beta -Djib.from.platforms="$PLATFORM" -Djib.to.image=localhost:5000/typestream/tools-seeder:beta :tools:jibDockerBuild

--- a/scripts/dev/shell.sh
+++ b/scripts/dev/shell.sh
@@ -5,6 +5,6 @@ IFS=$'\n\t'
 
 script_dir=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 
-cd "$script_dir"/../cli
+cd "$script_dir"/../../cli
 
 go run main.go

--- a/server/build.gradle.kts
+++ b/server/build.gradle.kts
@@ -3,7 +3,7 @@ plugins {
 
     //TODO It would be nice to package the code here and the gradle task it depends on in the same place.
     id("typestream.version-info")
-    id("com.google.cloud.tools.jib") version "3.4.0"
+    id("com.google.cloud.tools.jib") version "3.4.2"
     application
 }
 

--- a/tools/build.gradle.kts
+++ b/tools/build.gradle.kts
@@ -3,7 +3,7 @@ plugins {
 
     //TODO It would be nice to package the code here and the gradle task it depends on in the same place.
     id("typestream.version-info")
-    id("com.google.cloud.tools.jib") version "3.4.0"
+    id("com.google.cloud.tools.jib") version "3.4.2"
     application
 }
 


### PR DESCRIPTION
I also upgraded jib and fixed a problem with the shell.sh script.

It may be worth creating a small "lib" script at some point