### PR TITLE
chore(docker): Update Docker Hub name to non-deprecated one

### DIFF
--- a/libs/testing/src/main/kotlin/io/typestream/testing/TestKafka.kt
+++ b/libs/testing/src/main/kotlin/io/typestream/testing/TestKafka.kt
@@ -5,7 +5,7 @@ import io.typestream.testing.kafka.KafkaProducerWrapper
 import io.typestream.testing.model.TestRecord
 import org.testcontainers.redpanda.RedpandaContainer
 
-class TestKafka : RedpandaContainer("docker.redpanda.com/vectorized/redpanda:v24.2.9") {
+class TestKafka : RedpandaContainer("docker.redpanda.com/redpandadata/redpanda:v24.2.9") {
     fun produceRecords(topic: String, encoding: String, vararg records: TestRecord): List<TestRecord> {
         val adminClient = AdminClientWrapper(bootstrapServers)
         adminClient.createTopics(topic)


### PR DESCRIPTION
![CleanShot 2025-02-23 at 14 13 28@2x](https://github.com/user-attachments/assets/9c94dd20-83ab-431d-91cc-85b2a5a334d3)
