### PR TITLE
chore: parallel tests as per testcontainers doc

### DIFF
--- a/server/src/test/kotlin/io/typestream/kafka/SchemaRegistryClientTest.kt
+++ b/server/src/test/kotlin/io/typestream/kafka/SchemaRegistryClientTest.kt
@@ -15,8 +15,12 @@ import org.testcontainers.junit.jupiter.Testcontainers
 @Testcontainers
 internal class SchemaRegistryClientTest {
 
-    @Container
-    private val testKafka = TestKafka()
+    companion object {
+        // Shared container - starts once for all test methods in this class
+        @Container
+        @JvmStatic
+        private val testKafka = TestKafka()
+    }
 
     @Test
     fun `fetches schemas`() {


### PR DESCRIPTION
I was able to go from `4m 13s` -> `3m 20s` on my local machine. :tada: 