### PR TITLE
chore: Upgrading to Kotlin 2.3.0 and Gradle to 9.2.1

### DIFF
--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -8,8 +8,8 @@ repositories {
 }
 
 dependencies {
-    implementation("org.jetbrains.kotlin:kotlin-gradle-plugin:2.1.0")
-    implementation("org.jetbrains.kotlin:kotlin-serialization:2.1.0")
+    implementation("org.jetbrains.kotlin:kotlin-gradle-plugin:2.3.0")
+    implementation("org.jetbrains.kotlin:kotlin-serialization:2.3.0")
     implementation("com.adarshr:gradle-test-logger-plugin:4.0.0")
-    implementation("org.jetbrains.kotlinx:kover:0.6.1")
+    implementation("org.jetbrains.kotlinx:kover-gradle-plugin:0.9.4")
 }

--- a/buildSrc/src/main/kotlin/typestream.kotlin-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/typestream.kotlin-conventions.gradle.kts
@@ -14,8 +14,8 @@ repositories {
 }
 
 dependencies {
-    implementation("org.jetbrains.kotlin:kotlin-stdlib:2.1.0")
-    implementation("org.jetbrains.kotlin:kotlin-reflect:2.1.0")
+    implementation("org.jetbrains.kotlin:kotlin-stdlib:2.3.0")
+    implementation("org.jetbrains.kotlin:kotlin-reflect:2.3.0")
     implementation("org.jetbrains.kotlinx:kotlinx-datetime:0.6.1")
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.10.1")
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm:1.10.1")
@@ -41,7 +41,7 @@ tasks.test {
 }
 
 kotlin {
-    jvmToolchain(21)
+    jvmToolchain(25)
 
     target {
         compilerOptions {
@@ -51,8 +51,8 @@ kotlin {
 }
 
 java {
-    sourceCompatibility = JavaVersion.VERSION_21
-    targetCompatibility = JavaVersion.VERSION_21
+    sourceCompatibility = JavaVersion.VERSION_25
+    targetCompatibility = JavaVersion.VERSION_25
 }
 
 testlogger {

--- a/flake.lock
+++ b/flake.lock
@@ -2,16 +2,16 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1751274312,
-        "narHash": "sha256-/bVBlRpECLVzjV19t5KMdMFWSwKLtb5RyXdjz3LJT+g=",
+        "lastModified": 1767634882,
+        "narHash": "sha256-2GffSfQxe3sedHzK+sTKlYo/NTIAGzbFCIsNMUPAAnk=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "50ab793786d9de88ee30ec4e4c24fb4236fc2674",
+        "rev": "3c9db02515ef1d9b6b709fc60ba9a540957f661c",
         "type": "github"
       },
       "original": {
         "owner": "nixos",
-        "ref": "nixos-24.11",
+        "ref": "nixos-25.11",
         "repo": "nixpkgs",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -2,7 +2,7 @@
   description = "A Nix-flake-based Kotlin development environment";
 
   inputs = {
-    nixpkgs.url = "github:nixos/nixpkgs/nixos-24.11";
+    nixpkgs.url = "github:nixos/nixpkgs/nixos-25.11";
   };
 
   outputs =
@@ -11,7 +11,7 @@
       nixpkgs,
     }:
     let
-      javaVersion = 21;
+      javaVersion = 25;
       overlays = [
         (final: prev: rec {
           jdk = prev."jdk${toString javaVersion}";

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.12.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.2.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -21,7 +21,7 @@ dependencyResolutionManagement {
             version("kafka", "3.1.0")
             version("kubernetes-client", "6.9.0")
             version("okhttp", "4.12.0")
-            version("mockk", "1.13.9")
+            version("mockk", "1.14.3")
             version("protobuf", "3.24.2")
             version("rocksdbjni", "6.29.4.1")
             version("slf4j", "2.0.7")


### PR DESCRIPTION
- ~Upgrading to JDK 25 (including flake.nix reference) Couldn't do this since Gradle doesn't have 25 built in yet.~
- Upgrading to Kotlin 2.3.0
- Upgrading Gradle
