### PR TITLE
fix: Align CI workflow versions with flake.nix

### DIFF
--- a/.github/workflows/frontend-check.yml
+++ b/.github/workflows/frontend-check.yml
@@ -20,11 +20,11 @@ jobs:
   uiv2:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Setup Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
-          node-version: '18'
+          node-version: '22'
       - name: Enable Corepack
         run: corepack enable
       - name: Install dependencies
@@ -40,11 +40,11 @@ jobs:
   docs:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Setup Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
-          node-version: '18'
+          node-version: '22'
       - name: Install dependencies
         working-directory: docs
         run: npm ci

--- a/.github/workflows/server-check.yml
+++ b/.github/workflows/server-check.yml
@@ -39,11 +39,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
-      - name: Set up JDK 17
-        uses: actions/setup-java@v3
+      - uses: actions/checkout@v4
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
         with:
-          java-version: "17"
+          java-version: "21"
           distribution: "corretto"
       - name: Check
         uses: gradle/actions/setup-gradle@v3


### PR DESCRIPTION
## Summary

- Updates Java from 17 → 21 in `server-check.yml` to match `flake.nix` and project's `sourceCompatibility = JavaVersion.VERSION_21`
- Updates Node from 18 → 22 in `frontend-check.yml` to match `flake.nix` (`nodejs_22`)
- Updates GitHub Actions to v4: `actions/checkout`, `actions/setup-java`, `actions/setup-node`

## Test plan

- [ ] Verify `server-check` workflow passes with Java 21
- [ ] Verify `frontend-check` workflow passes with Node 22 (both uiv2 and docs jobs)

Closes #151

🤖 Generated with [Claude Code](https://claude.com/claude-code)