### PR TITLE
fix: Share GeoIpService instance to prevent resource leaks

### DIFF
--- a/server/src/main/kotlin/io/typestream/compiler/kafka/KafkaStreamSource.kt
+++ b/server/src/main/kotlin/io/typestream/compiler/kafka/KafkaStreamSource.kt
@@ -31,7 +31,7 @@ import java.time.Duration
 data class KafkaStreamSource(
     val node: Node.StreamSource,
     private val streamsBuilder: StreamsBuilderWrapper,
-    private val geoIpService: GeoIpService = GeoIpService()
+    private val geoIpService: GeoIpService
 ) {
     private var stream: KStream<DataStream, DataStream> = stream(node.dataStream)
     private var groupedStream: KGroupedStream<DataStream, DataStream>? = null

--- a/server/src/main/kotlin/io/typestream/compiler/vm/Vm.kt
+++ b/server/src/main/kotlin/io/typestream/compiler/vm/Vm.kt
@@ -30,7 +30,7 @@ class Vm(val fileSystem: FileSystem, val scheduler: Scheduler) {
 
                 logger.info { "starting kafka streams job for ${program.id}" }
 
-                KafkaStreamsJob(program.id, program, kafkaConfig).start()
+                KafkaStreamsJob(program.id, program, kafkaConfig, geoIpService).start()
             }
 
             SHELL -> {
@@ -59,7 +59,7 @@ class Vm(val fileSystem: FileSystem, val scheduler: Scheduler) {
                 val kafkaConfig = fileSystem.config.sources.kafka[runtime.name]
                     ?: error("cluster ${runtime.name} not found")
 
-                scheduler.schedule(KafkaStreamsJob(program.id, program, kafkaConfig))
+                scheduler.schedule(KafkaStreamsJob(program.id, program, kafkaConfig, geoIpService))
                 val stdOut = if (!program.hasMoreOutput()) "running ${program.id} in the background" else ""
                 VmResult(program, ProgramOutput(stdOut, ""))
             }

--- a/server/src/main/kotlin/io/typestream/scheduler/KafkaStreamsJob.kt
+++ b/server/src/main/kotlin/io/typestream/scheduler/KafkaStreamsJob.kt
@@ -6,6 +6,7 @@ import io.typestream.compiler.kafka.KafkaStreamSource
 import io.typestream.compiler.node.Node
 import io.typestream.compiler.types.DataStream
 import io.typestream.config.KafkaConfig
+import io.typestream.geoip.GeoIpService
 import io.typestream.coroutine.retry
 import io.typestream.kafka.DataStreamSerde
 import io.typestream.kafka.StreamsBuilderWrapper
@@ -21,7 +22,12 @@ import kotlin.time.Duration.Companion.seconds
 import kotlin.time.toJavaDuration
 
 
-class KafkaStreamsJob(override val id: String, val program: Program, private val kafkaConfig: KafkaConfig) : Job {
+class KafkaStreamsJob(
+    override val id: String,
+    val program: Program,
+    private val kafkaConfig: KafkaConfig,
+    private val geoIpService: GeoIpService
+) : Job {
     private var running: Boolean = false
     private val logger = KotlinLogging.logger {}
     private var kafkaStreams: KafkaStreams? = null
@@ -35,7 +41,7 @@ class KafkaStreamsJob(override val id: String, val program: Program, private val
             val source = sourceNode.ref
             require(source is Node.StreamSource) { "source node must be a StreamSource" }
 
-            val kafkaStreamSource = KafkaStreamSource(source, streamsBuilder)
+            val kafkaStreamSource = KafkaStreamSource(source, streamsBuilder, geoIpService)
 
             sourceNode.walk { currentNode ->
                 when (currentNode.ref) {


### PR DESCRIPTION
## Summary
- Fix resource leak where `KafkaStreamSource` created a new `GeoIpService` per stream source node
- The `DatabaseReader` file handles were never closed when jobs stopped
- Now `GeoIpService` is injected from `Vm` through `KafkaStreamsJob`, ensuring a single shared instance

## Test plan
- [x] Server compiles successfully
- [x] All 176 server tests pass