### PR TITLE
fix: Replace Java boxed types with Kotlin javaObjectType

### DIFF
--- a/server/src/test/kotlin/io/typestream/compiler/types/datastream/AvroExtKtTest.kt
+++ b/server/src/test/kotlin/io/typestream/compiler/types/datastream/AvroExtKtTest.kt
@@ -113,12 +113,12 @@ internal class AvroExtKtTest {
         assertThat(avroRecord.get("stringField")).isEqualTo("5")
 
         // Verify temporal fields are converted to correct primitive types (the actual fix)
-        assertThat(avroRecord.get("dateField")).isInstanceOf(java.lang.Integer::class.java)
-        assertThat(avroRecord.get("timestampMillisField")).isInstanceOf(java.lang.Long::class.java)
-        assertThat(avroRecord.get("timestampMicrosField")).isInstanceOf(java.lang.Long::class.java)
-        assertThat(avroRecord.get("localTimestampMillisField")).isInstanceOf(java.lang.Long::class.java)
-        assertThat(avroRecord.get("localTimestampMicrosField")).isInstanceOf(java.lang.Long::class.java)
-        assertThat(avroRecord.get("timeMillisField")).isInstanceOf(java.lang.Integer::class.java)
-        assertThat(avroRecord.get("timeMicrosField")).isInstanceOf(java.lang.Long::class.java)
+        assertThat(avroRecord.get("dateField")).isInstanceOf(Int::class.javaObjectType)
+        assertThat(avroRecord.get("timestampMillisField")).isInstanceOf(Long::class.javaObjectType)
+        assertThat(avroRecord.get("timestampMicrosField")).isInstanceOf(Long::class.javaObjectType)
+        assertThat(avroRecord.get("localTimestampMillisField")).isInstanceOf(Long::class.javaObjectType)
+        assertThat(avroRecord.get("localTimestampMicrosField")).isInstanceOf(Long::class.javaObjectType)
+        assertThat(avroRecord.get("timeMillisField")).isInstanceOf(Int::class.javaObjectType)
+        assertThat(avroRecord.get("timeMicrosField")).isInstanceOf(Long::class.javaObjectType)
     }
 }


### PR DESCRIPTION
## Summary
- Replace `java.lang.Integer::class.java` with `Int::class.javaObjectType` in test assertions
- Replace `java.lang.Long::class.java` with `Long::class.javaObjectType` in test assertions
- Eliminates 7 Kotlin compiler warnings about using Java boxed types

## Context
The Kotlin compiler warns when using Java boxed types (`java.lang.Integer`, `java.lang.Long`) directly, recommending Kotlin's native types instead. Using `javaObjectType` is the idiomatic way to get the Java boxed class in Kotlin without triggering the warning.

## Test plan
- [ ] Run `./gradlew :server:compileTestKotlin` and verify warnings are gone
- [ ] Run `./gradlew :server:test` to ensure tests still pass