### PR TITLE
feat: Add EmbeddingGenerator node for vector embeddings (#164)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,5 +10,6 @@ out
 .divenv/
 .direnv
 .envrc
+.env
 .kotlin/
 kls_database.db

--- a/cli/pkg/compose/.env.example
+++ b/cli/pkg/compose/.env.example
@@ -1,0 +1,5 @@
+# Copy this file to .env and fill in your values
+# .env is gitignored and will not be committed
+
+# OpenAI API key for embedding generation
+OPENAI_API_KEY=your-api-key-here

--- a/cli/pkg/compose/compose.yml
+++ b/cli/pkg/compose/compose.yml
@@ -36,6 +36,7 @@ services:
     image: ${TYPESTREAM_IMAGE:-typestream/server:latest}
     environment:
       TIKA_URL: http://tika:9998
+      OPENAI_API_KEY: ${OPENAI_API_KEY:-}
       TYPESTREAM_CONFIG: |-
         [grpc]
         port=4242

--- a/protos/src/main/proto/job.proto
+++ b/protos/src/main/proto/job.proto
@@ -103,6 +103,12 @@ message TextExtractorNode {
   string output_field = 2;     // Output field name (default: text)
 }
 
+message EmbeddingGeneratorNode {
+  string text_field = 1;     // Field containing text to embed
+  string output_field = 2;   // Output field name (default: embedding)
+  string model = 3;          // OpenAI model (default: text-embedding-3-small)
+}
+
 message PipelineNode {
   string id = 1;
   oneof node_type {
@@ -120,6 +126,7 @@ message PipelineNode {
     InspectorNode inspector = 13;
     ReduceLatestNode reduce_latest = 14;
     TextExtractorNode text_extractor = 15;
+    EmbeddingGeneratorNode embedding_generator = 16;
   }
 }
 

--- a/scripts/dev/server.sh
+++ b/scripts/dev/server.sh
@@ -6,6 +6,15 @@ set -eu
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
 
+# Load .env file if it exists (for OPENAI_API_KEY, etc.)
+ENV_FILE="$PROJECT_ROOT/cli/pkg/compose/.env"
+if [[ -f "$ENV_FILE" ]]; then
+    echo "Loading environment from $ENV_FILE"
+    set -a  # automatically export all variables
+    source "$ENV_FILE"
+    set +a
+fi
+
 export TYPESTREAM_CONFIG_PATH="$SCRIPT_DIR"
 export TIKA_URL="http://localhost:9998"
 

--- a/server/src/main/kotlin/io/typestream/compiler/GraphCompiler.kt
+++ b/server/src/main/kotlin/io/typestream/compiler/GraphCompiler.kt
@@ -6,6 +6,7 @@ import io.typestream.compiler.types.DataStream
 import io.typestream.compiler.types.Encoding
 import io.typestream.compiler.types.schema.Schema
 import io.typestream.filesystem.FileSystem
+import io.typestream.embedding.EmbeddingGeneratorNodeHandler
 import io.typestream.geoip.GeoIpNodeHandler
 import io.typestream.textextractor.TextExtractorNodeHandler
 import io.typestream.graph.Graph
@@ -110,6 +111,7 @@ class GraphCompiler(private val fileSystem: FileSystem) {
     }
     proto.hasReduceLatest() -> Node.ReduceLatest(proto.id)
     proto.hasTextExtractor() -> TextExtractorNodeHandler.fromProto(proto)
+    proto.hasEmbeddingGenerator() -> EmbeddingGeneratorNodeHandler.fromProto(proto)
     else -> error("Unknown node type: $proto")
   }
 
@@ -230,6 +232,14 @@ class GraphCompiler(private val fileSystem: FileSystem) {
           input ?: error("textExtractor $nodeId missing input"),
           proto.textExtractor.filePathField,
           proto.textExtractor.outputField.ifBlank { "text" }
+        )
+        out to (inputEncoding ?: Encoding.AVRO)
+      }
+      proto.hasEmbeddingGenerator() -> {
+        val out = EmbeddingGeneratorNodeHandler.inferType(
+          input ?: error("embeddingGenerator $nodeId missing input"),
+          proto.embeddingGenerator.textField,
+          proto.embeddingGenerator.outputField.ifBlank { "embedding" }
         )
         out to (inputEncoding ?: Encoding.AVRO)
       }

--- a/server/src/main/kotlin/io/typestream/compiler/Infer.kt
+++ b/server/src/main/kotlin/io/typestream/compiler/Infer.kt
@@ -46,6 +46,10 @@ object Infer {
                 val stream = input ?: error("textExtractor ${ref.id} missing input stream")
                 TypeRules.inferTextExtractor(stream, ref.filePathField, ref.outputField)
             }
+            is Node.EmbeddingGenerator -> {
+                val stream = input ?: error("embeddingGenerator ${ref.id} missing input stream")
+                TypeRules.inferEmbeddingGenerator(stream, ref.textField, ref.outputField)
+            }
             is Node.Inspector -> input ?: error("inspector ${ref.id} missing input stream")
         }
 

--- a/server/src/main/kotlin/io/typestream/compiler/kafka/KafkaStreamSource.kt
+++ b/server/src/main/kotlin/io/typestream/compiler/kafka/KafkaStreamSource.kt
@@ -13,6 +13,8 @@ import io.typestream.compiler.types.datastream.toAvroSchema
 import io.typestream.compiler.types.datastream.toBytes
 import io.typestream.compiler.types.datastream.toProtoMessage
 import io.typestream.compiler.types.datastream.toProtoSchema
+import io.typestream.embedding.EmbeddingGeneratorExecution
+import io.typestream.embedding.EmbeddingGeneratorService
 import io.typestream.geoip.GeoIpExecution
 import io.typestream.geoip.GeoIpService
 import io.typestream.textextractor.TextExtractorExecution
@@ -37,7 +39,8 @@ data class KafkaStreamSource(
     val node: Node.StreamSource,
     private val streamsBuilder: StreamsBuilderWrapper,
     private val geoIpService: GeoIpService,
-    private val textExtractorService: TextExtractorService
+    private val textExtractorService: TextExtractorService,
+    private val embeddingGeneratorService: EmbeddingGeneratorService
 ) {
     private var stream: KStream<DataStream, DataStream> = stream(node.dataStream)
     private var groupedStream: KGroupedStream<DataStream, DataStream>? = null
@@ -169,6 +172,10 @@ data class KafkaStreamSource(
 
     fun textExtract(textExtractor: Node.TextExtractor) {
         stream = TextExtractorExecution.applyToKafka(textExtractor, stream, textExtractorService)
+    }
+
+    fun embeddingGenerate(embeddingGenerator: Node.EmbeddingGenerator) {
+        stream = EmbeddingGeneratorExecution.applyToKafka(embeddingGenerator, stream, embeddingGeneratorService)
     }
 
     fun toInspector(inspector: Node.Inspector, programId: String) {

--- a/server/src/main/kotlin/io/typestream/compiler/node/Node.kt
+++ b/server/src/main/kotlin/io/typestream/compiler/node/Node.kt
@@ -50,4 +50,12 @@ sealed interface Node {
 
     @Serializable
     data class TextExtractor(override val id: String, val filePathField: String, val outputField: String) : Node
+
+    @Serializable
+    data class EmbeddingGenerator(
+        override val id: String,
+        val textField: String,
+        val outputField: String,
+        val model: String
+    ) : Node
 }

--- a/server/src/main/kotlin/io/typestream/compiler/types/TypeRules.kt
+++ b/server/src/main/kotlin/io/typestream/compiler/types/TypeRules.kt
@@ -198,4 +198,29 @@ object TypeRules {
     val newFields = inputSchema.value + newField
     return input.copy(schema = Schema.Struct(newFields))
   }
+
+  /**
+   * Type inference for EmbeddingGenerator nodes.
+   * Adds a new List<Float> field (embedding vector) to the schema.
+   * The EmbeddingGenerator node takes a text field from the input and adds an embedding vector field to the output.
+   *
+   * @param input The input stream schema
+   * @param textField The name of the field containing the text to embed
+   * @param outputField The name of the output field for the embedding vector (e.g., "embedding")
+   * @return Input schema with the new embedding field added
+   * @throws IllegalArgumentException if input schema is not a struct or if textField doesn't exist
+   */
+  fun inferEmbeddingGenerator(input: DataStream, textField: String, outputField: String): DataStream {
+    val inputSchema = input.schema
+    require(inputSchema is Schema.Struct) { "EmbeddingGenerator requires struct schema, got: ${inputSchema::class.simpleName}" }
+
+    val hasTextField = inputSchema.value.any { it.name == textField }
+    require(hasTextField) { "EmbeddingGenerator text field '$textField' not found in schema. Available fields: ${inputSchema.value.map { it.name }}" }
+
+    // Embedding is a List<Float>
+    val embeddingType = Schema.List(emptyList(), Schema.Float(0.0f))
+    val newField = Schema.Field(outputField, embeddingType)
+    val newFields = inputSchema.value + newField
+    return input.copy(schema = Schema.Struct(newFields))
+  }
 }

--- a/server/src/main/kotlin/io/typestream/embedding/EmbeddingGeneratorExecution.kt
+++ b/server/src/main/kotlin/io/typestream/embedding/EmbeddingGeneratorExecution.kt
@@ -1,0 +1,60 @@
+package io.typestream.embedding
+
+import io.typestream.compiler.node.Node
+import io.typestream.compiler.types.DataStream
+import io.typestream.compiler.types.schema.Schema
+import org.apache.kafka.streams.kstream.KStream
+
+/**
+ * Execution strategies for EmbeddingGenerator node on different runtimes.
+ */
+object EmbeddingGeneratorExecution {
+
+    /**
+     * Apply EmbeddingGenerator transformation to a list of DataStreams (Shell runtime).
+     *
+     * @param node The EmbeddingGenerator node configuration
+     * @param dataStreams Input data streams to transform
+     * @param embeddingService Service for embedding generation
+     * @return Transformed data streams with embedding vector field added
+     */
+    fun applyToShell(
+        node: Node.EmbeddingGenerator,
+        dataStreams: List<DataStream>,
+        embeddingService: EmbeddingGeneratorService
+    ): List<DataStream> {
+        return dataStreams.map { ds ->
+            val text = ds.selectFieldAsString(node.textField) ?: ""
+            val embedding = embeddingService.embed(text, node.model) ?: emptyList()
+            val embeddingSchema = Schema.List(
+                embedding.map { Schema.Float(it) },
+                Schema.Float(0.0f)
+            )
+            ds.addField(node.outputField, embeddingSchema)
+        }
+    }
+
+    /**
+     * Apply EmbeddingGenerator transformation to a Kafka stream.
+     *
+     * @param node The EmbeddingGenerator node configuration
+     * @param stream Input Kafka stream to transform
+     * @param embeddingService Service for embedding generation
+     * @return Transformed stream with embedding vector field added to each record
+     */
+    fun applyToKafka(
+        node: Node.EmbeddingGenerator,
+        stream: KStream<DataStream, DataStream>,
+        embeddingService: EmbeddingGeneratorService
+    ): KStream<DataStream, DataStream> {
+        return stream.mapValues { value ->
+            val text = value.selectFieldAsString(node.textField) ?: ""
+            val embedding = embeddingService.embed(text, node.model) ?: emptyList()
+            val embeddingSchema = Schema.List(
+                embedding.map { Schema.Float(it) },
+                Schema.Float(0.0f)
+            )
+            value.addField(node.outputField, embeddingSchema)
+        }
+    }
+}

--- a/server/src/main/kotlin/io/typestream/embedding/EmbeddingGeneratorNodeHandler.kt
+++ b/server/src/main/kotlin/io/typestream/embedding/EmbeddingGeneratorNodeHandler.kt
@@ -1,0 +1,46 @@
+package io.typestream.embedding
+
+import io.typestream.compiler.node.Node
+import io.typestream.compiler.types.DataStream
+import io.typestream.compiler.types.TypeRules
+import io.typestream.grpc.job_service.Job
+
+/**
+ * Handler for EmbeddingGenerator pipeline nodes.
+ * Centralizes proto-to-node conversion and type inference for embedding generation.
+ */
+object EmbeddingGeneratorNodeHandler {
+
+    private const val DEFAULT_OUTPUT_FIELD = "embedding"
+    private const val DEFAULT_MODEL = "text-embedding-3-small"
+
+    /**
+     * Check if this handler can process the given proto node.
+     */
+    fun canHandle(proto: Job.PipelineNode): Boolean = proto.hasEmbeddingGenerator()
+
+    /**
+     * Convert EmbeddingGenerator proto to internal Node type.
+     */
+    fun fromProto(proto: Job.PipelineNode): Node.EmbeddingGenerator {
+        require(proto.hasEmbeddingGenerator()) { "Expected EmbeddingGenerator node, got: ${proto.nodeTypeCase}" }
+        val e = proto.embeddingGenerator
+        val outputField = if (e.outputField.isBlank()) DEFAULT_OUTPUT_FIELD else e.outputField
+        val model = if (e.model.isBlank()) DEFAULT_MODEL else e.model
+        return Node.EmbeddingGenerator(proto.id, e.textField, outputField, model)
+    }
+
+    /**
+     * Infer the output schema for an EmbeddingGenerator node.
+     * Adds a List<Float> field (embedding vector) to the input schema.
+     *
+     * @param input The input DataStream schema
+     * @param textField Name of the field containing text to embed
+     * @param outputField Name of the field to add (default: "embedding")
+     * @return DataStream with the new field added
+     * @throws IllegalArgumentException if textField doesn't exist in the input schema
+     */
+    fun inferType(input: DataStream, textField: String, outputField: String): DataStream {
+        return TypeRules.inferEmbeddingGenerator(input, textField, outputField)
+    }
+}

--- a/server/src/main/kotlin/io/typestream/embedding/EmbeddingGeneratorService.kt
+++ b/server/src/main/kotlin/io/typestream/embedding/EmbeddingGeneratorService.kt
@@ -1,0 +1,92 @@
+package io.typestream.embedding
+
+import io.github.oshai.kotlinlogging.KotlinLogging
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+import java.io.Closeable
+import java.net.URI
+import java.net.http.HttpClient
+import java.net.http.HttpRequest
+import java.net.http.HttpResponse
+
+/**
+ * Service for generating text embeddings using OpenAI's embedding API.
+ */
+open class EmbeddingGeneratorService(
+    private val apiKey: String = defaultApiKey()
+) : Closeable {
+    private val logger = KotlinLogging.logger {}
+    private val httpClient = HttpClient.newHttpClient()
+    private val json = Json { ignoreUnknownKeys = true }
+
+    @Serializable
+    private data class EmbeddingRequest(
+        val input: String,
+        val model: String
+    )
+
+    @Serializable
+    private data class EmbeddingResponse(
+        val data: List<EmbeddingData>
+    )
+
+    @Serializable
+    private data class EmbeddingData(
+        val embedding: List<Float>,
+        val index: Int
+    )
+
+    /**
+     * Generate embeddings for the given text.
+     * @param text The text to embed
+     * @param model The embedding model to use (default: text-embedding-3-small)
+     * @return List of floats representing the embedding vector, or null if generation failed
+     */
+    open fun embed(text: String, model: String = "text-embedding-3-small"): List<Float>? {
+        if (apiKey.isBlank()) {
+            logger.warn { "OpenAI API key not configured. Set OPENAI_API_KEY environment variable." }
+            return null
+        }
+
+        return try {
+            val requestBody = json.encodeToString(EmbeddingRequest.serializer(), EmbeddingRequest(text, model))
+
+            val request = HttpRequest.newBuilder()
+                .uri(URI.create("https://api.openai.com/v1/embeddings"))
+                .header("Content-Type", "application/json")
+                .header("Authorization", "Bearer $apiKey")
+                .POST(HttpRequest.BodyPublishers.ofString(requestBody))
+                .build()
+
+            val response = httpClient.send(request, HttpResponse.BodyHandlers.ofString())
+
+            if (response.statusCode() == 200) {
+                val embeddingResponse = json.decodeFromString(EmbeddingResponse.serializer(), response.body())
+                embeddingResponse.data.firstOrNull()?.embedding
+            } else {
+                logger.warn { "OpenAI embedding failed: HTTP ${response.statusCode()} - ${response.body()}" }
+                null
+            }
+        } catch (e: Exception) {
+            logger.debug { "Embedding generation failed: ${e.message}" }
+            null
+        }
+    }
+
+    /**
+     * Check if the OpenAI API is available and configured.
+     */
+    fun isAvailable(): Boolean {
+        return apiKey.isNotBlank()
+    }
+
+    override fun close() {
+        // HttpClient doesn't need explicit cleanup in Java 11+
+    }
+
+    companion object {
+        fun defaultApiKey(): String {
+            return System.getenv("OPENAI_API_KEY") ?: ""
+        }
+    }
+}

--- a/server/src/test/kotlin/io/typestream/compiler/types/TypeRulesTest.kt
+++ b/server/src/test/kotlin/io/typestream/compiler/types/TypeRulesTest.kt
@@ -229,4 +229,117 @@ internal class TypeRulesTest {
             assertThat(fieldNames).containsExactly("document_path", "content")
         }
     }
+
+    @Nested
+    inner class InferEmbeddingGenerator {
+
+        private val inputSchema = Schema.Struct(
+            listOf(
+                Schema.Field("id", Schema.String("123")),
+                Schema.Field("text_content", Schema.String("Hello world")),
+                Schema.Field("name", Schema.String("test"))
+            )
+        )
+
+        private val inputDataStream = DataStream("/test/topic", inputSchema)
+
+        @Test
+        fun `adds embedding field to output schema`() {
+            val result = TypeRules.inferEmbeddingGenerator(inputDataStream, "text_content", "embedding")
+
+            val outputSchema = result.schema as Schema.Struct
+            val fieldNames = outputSchema.value.map { it.name }
+            assertThat(fieldNames).containsExactly("id", "text_content", "name", "embedding")
+        }
+
+        @Test
+        fun `new field has List of Float type`() {
+            val result = TypeRules.inferEmbeddingGenerator(inputDataStream, "text_content", "embedding")
+
+            val outputSchema = result.schema as Schema.Struct
+            val embeddingField = outputSchema.value.find { it.name == "embedding" }
+            assertThat(embeddingField?.value).isInstanceOf(Schema.List::class.java)
+            val listSchema = embeddingField?.value as Schema.List
+            assertThat(listSchema.valueType).isInstanceOf(Schema.Float::class.java)
+        }
+
+        @Test
+        fun `preserves original fields`() {
+            val result = TypeRules.inferEmbeddingGenerator(inputDataStream, "text_content", "embedding")
+
+            val outputSchema = result.schema as Schema.Struct
+            val idField = outputSchema.value.find { it.name == "id" }
+            val textField = outputSchema.value.find { it.name == "text_content" }
+            val nameField = outputSchema.value.find { it.name == "name" }
+
+            assertThat(idField?.value).isEqualTo(Schema.String("123"))
+            assertThat(textField?.value).isEqualTo(Schema.String("Hello world"))
+            assertThat(nameField?.value).isEqualTo(Schema.String("test"))
+        }
+
+        @Test
+        fun `preserves original path`() {
+            val result = TypeRules.inferEmbeddingGenerator(inputDataStream, "text_content", "embedding")
+
+            assertThat(result.path).isEqualTo("/test/topic")
+        }
+
+        @Test
+        fun `uses custom output field name`() {
+            val result = TypeRules.inferEmbeddingGenerator(inputDataStream, "text_content", "vector")
+
+            val outputSchema = result.schema as Schema.Struct
+            val fieldNames = outputSchema.value.map { it.name }
+            assertThat(fieldNames).contains("vector")
+            assertThat(fieldNames).doesNotContain("embedding")
+        }
+
+        @Test
+        fun `throws error when text field does not exist`() {
+            assertThatThrownBy {
+                TypeRules.inferEmbeddingGenerator(inputDataStream, "nonexistent_field", "embedding")
+            }
+                .isInstanceOf(IllegalArgumentException::class.java)
+                .hasMessageContaining("text field 'nonexistent_field' not found in schema")
+                .hasMessageContaining("Available fields:")
+        }
+
+        @Test
+        fun `error message lists available fields`() {
+            assertThatThrownBy {
+                TypeRules.inferEmbeddingGenerator(inputDataStream, "nonexistent_field", "embedding")
+            }
+                .hasMessageContaining("id")
+                .hasMessageContaining("text_content")
+                .hasMessageContaining("name")
+        }
+
+        @Test
+        fun `throws error for non-struct schema`() {
+            val stringSchema = Schema.String("test")
+            val nonStructDataStream = DataStream("/test/topic", stringSchema)
+
+            assertThatThrownBy {
+                TypeRules.inferEmbeddingGenerator(nonStructDataStream, "text_content", "embedding")
+            }
+                .isInstanceOf(IllegalArgumentException::class.java)
+                .hasMessageContaining("EmbeddingGenerator requires struct schema")
+        }
+
+        @Test
+        fun `works with different field names for text`() {
+            val schemaWithDifferentTextField = Schema.Struct(
+                listOf(
+                    Schema.Field("description", Schema.String("Some description")),
+                )
+            )
+            val dataStream = DataStream("/test/topic", schemaWithDifferentTextField)
+
+            val result = TypeRules.inferEmbeddingGenerator(dataStream, "description", "desc_embedding")
+
+            val outputSchema = result.schema as Schema.Struct
+            val fieldNames = outputSchema.value.map { it.name }
+            assertThat(fieldNames).containsExactly("description", "desc_embedding")
+        }
+    }
 }

--- a/server/src/test/kotlin/io/typestream/embedding/EmbeddingGeneratorServiceTest.kt
+++ b/server/src/test/kotlin/io/typestream/embedding/EmbeddingGeneratorServiceTest.kt
@@ -1,0 +1,98 @@
+package io.typestream.embedding
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+
+internal class EmbeddingGeneratorServiceTest {
+
+    @Nested
+    inner class EmbedWithMissingApiKey {
+        @Test
+        fun `embed returns null when API key is blank`() {
+            val service = EmbeddingGeneratorService("")
+
+            val result = service.embed("Hello, World!")
+
+            assertThat(result).isNull()
+        }
+
+        @Test
+        fun `isAvailable returns false when API key is blank`() {
+            val service = EmbeddingGeneratorService("")
+
+            assertThat(service.isAvailable()).isFalse
+        }
+    }
+
+    @Nested
+    inner class EmbedWithInvalidApiKey {
+        @Test
+        fun `embed returns null when API key is invalid`() {
+            val service = EmbeddingGeneratorService("invalid-key")
+
+            val result = service.embed("Hello, World!")
+
+            assertThat(result).isNull()
+        }
+    }
+
+    @Nested
+    inner class ResourceManagement {
+        @Test
+        fun `close can be called without error`() {
+            val service = EmbeddingGeneratorService("")
+
+            // Should not throw
+            service.close()
+        }
+
+        @Test
+        fun `service implements Closeable`() {
+            val service = EmbeddingGeneratorService("")
+
+            assertThat(service).isInstanceOf(java.io.Closeable::class.java)
+        }
+    }
+
+    @Nested
+    inner class DefaultConfiguration {
+        @Test
+        fun `default API key uses OPENAI_API_KEY environment variable or empty string`() {
+            val defaultKey = EmbeddingGeneratorService.defaultApiKey()
+
+            // Either from env var or empty string
+            assertThat(defaultKey).isNotNull
+        }
+
+        @Test
+        fun `isAvailable returns true when API key is configured`() {
+            // Only test this if we have an API key set
+            val apiKey = System.getenv("OPENAI_API_KEY") ?: ""
+            if (apiKey.isBlank()) return
+
+            val service = EmbeddingGeneratorService(apiKey)
+            assertThat(service.isAvailable()).isTrue
+        }
+    }
+
+    @Nested
+    inner class ModelSelection {
+        @Test
+        fun `embed uses default model when not specified`() {
+            val service = EmbeddingGeneratorService("")
+            // Just verify that calling with text doesn't throw
+            // (API key is blank so it will return null gracefully)
+            val result = service.embed("test")
+            assertThat(result).isNull()
+        }
+
+        @Test
+        fun `embed accepts custom model parameter`() {
+            val service = EmbeddingGeneratorService("")
+            // Just verify that calling with custom model doesn't throw
+            val result = service.embed("test", "text-embedding-3-large")
+            assertThat(result).isNull()
+        }
+    }
+}

--- a/uiv2/src/components/graph-builder/GraphBuilder.tsx
+++ b/uiv2/src/components/graph-builder/GraphBuilder.tsx
@@ -65,6 +65,8 @@ export function GraphBuilder() {
         data = { aggregationType: 'count', groupByField: '' };
       } else if (type === 'textExtractor') {
         data = { filePathField: '', outputField: 'text' };
+      } else if (type === 'embeddingGenerator') {
+        data = { textField: '', outputField: 'embedding', model: 'text-embedding-3-small' };
       } else {
         data = { topicPath: '' };
       }

--- a/uiv2/src/components/graph-builder/NodePalette.tsx
+++ b/uiv2/src/components/graph-builder/NodePalette.tsx
@@ -6,6 +6,7 @@ import PublicIcon from '@mui/icons-material/Public';
 import VisibilityIcon from '@mui/icons-material/Visibility';
 import TableChartIcon from '@mui/icons-material/TableChart';
 import DescriptionIcon from '@mui/icons-material/Description';
+import MemoryIcon from '@mui/icons-material/Memory';
 import type { DragEvent } from 'react';
 
 interface PaletteItemProps {
@@ -89,6 +90,11 @@ export function NodePalette() {
         type="textExtractor"
         label="Text Extractor"
         icon={<DescriptionIcon fontSize="small" />}
+      />
+      <PaletteItem
+        type="embeddingGenerator"
+        label="Embedding Generator"
+        icon={<MemoryIcon fontSize="small" />}
       />
     </Paper>
   );

--- a/uiv2/src/components/graph-builder/nodes/EmbeddingGeneratorNode.tsx
+++ b/uiv2/src/components/graph-builder/nodes/EmbeddingGeneratorNode.tsx
@@ -1,0 +1,75 @@
+import { Handle, Position, useReactFlow, useNodes, useEdges, type NodeProps } from '@xyflow/react';
+import FormControl from '@mui/material/FormControl';
+import InputLabel from '@mui/material/InputLabel';
+import Select from '@mui/material/Select';
+import MenuItem from '@mui/material/MenuItem';
+import TextField from '@mui/material/TextField';
+import MemoryIcon from '@mui/icons-material/Memory';
+import { BaseNode } from './BaseNode';
+import { useTopicSchema } from '../../../hooks/useTopicSchema';
+import type { EmbeddingGeneratorNodeType, KafkaSourceNodeData } from './index';
+
+export function EmbeddingGeneratorNode({ id, data }: NodeProps<EmbeddingGeneratorNodeType>) {
+  const { updateNodeData } = useReactFlow();
+  const nodes = useNodes();
+  const edges = useEdges();
+
+  // Find the upstream source node to get the topic path for schema lookup
+  const incomingEdge = edges.find((e) => e.target === id);
+  const sourceNode = incomingEdge
+    ? nodes.find((n) => n.id === incomingEdge.source)
+    : null;
+
+  // Get topic path from the source node (if it's a kafka source)
+  const topicPath =
+    sourceNode?.type === 'kafkaSource'
+      ? (sourceNode.data as KafkaSourceNodeData).topicPath
+      : '';
+
+  const { fields, isLoading } = useTopicSchema(topicPath);
+
+  return (
+    <>
+      <Handle type="target" position={Position.Left} />
+      <BaseNode title="Embedding Generator" icon={<MemoryIcon fontSize="small" />}>
+        <FormControl fullWidth size="small" className="nodrag nowheel" sx={{ mb: 1.5 }}>
+          <InputLabel>Text Field</InputLabel>
+          <Select
+            value={data.textField}
+            label="Text Field"
+            onChange={(e) => updateNodeData(id, { textField: e.target.value })}
+            disabled={isLoading || fields.length === 0}
+          >
+            {fields.map((field) => (
+              <MenuItem key={field} value={field}>
+                {field}
+              </MenuItem>
+            ))}
+          </Select>
+        </FormControl>
+        <TextField
+          fullWidth
+          size="small"
+          label="Output Field"
+          value={data.outputField}
+          onChange={(e) => updateNodeData(id, { outputField: e.target.value })}
+          className="nodrag"
+          placeholder="embedding"
+          sx={{ mb: 1.5 }}
+        />
+        <FormControl fullWidth size="small" className="nodrag nowheel">
+          <InputLabel>Model</InputLabel>
+          <Select
+            value={data.model}
+            label="Model"
+            onChange={(e) => updateNodeData(id, { model: e.target.value })}
+          >
+            <MenuItem value="text-embedding-3-small">text-embedding-3-small</MenuItem>
+            <MenuItem value="text-embedding-3-large">text-embedding-3-large</MenuItem>
+          </Select>
+        </FormControl>
+      </BaseNode>
+      <Handle type="source" position={Position.Right} />
+    </>
+  );
+}

--- a/uiv2/src/components/graph-builder/nodes/index.ts
+++ b/uiv2/src/components/graph-builder/nodes/index.ts
@@ -5,6 +5,7 @@ import { GeoIpNode } from './GeoIpNode';
 import { InspectorNode } from './InspectorNode';
 import { MaterializedViewNode, type AggregationType } from './MaterializedViewNode';
 import { TextExtractorNode } from './TextExtractorNode';
+import { EmbeddingGeneratorNode } from './EmbeddingGeneratorNode';
 
 export interface KafkaSourceNodeData extends Record<string, unknown> {
   topicPath: string;
@@ -33,14 +34,21 @@ export interface TextExtractorNodeData extends Record<string, unknown> {
   outputField: string;
 }
 
+export interface EmbeddingGeneratorNodeData extends Record<string, unknown> {
+  textField: string;
+  outputField: string;
+  model: string;
+}
+
 export type KafkaSourceNodeType = Node<KafkaSourceNodeData, 'kafkaSource'>;
 export type KafkaSinkNodeType = Node<KafkaSinkNodeData, 'kafkaSink'>;
 export type GeoIpNodeType = Node<GeoIpNodeData, 'geoIp'>;
 export type InspectorNodeType = Node<InspectorNodeData, 'inspector'>;
 export type MaterializedViewNodeType = Node<MaterializedViewNodeData, 'materializedView'>;
 export type TextExtractorNodeType = Node<TextExtractorNodeData, 'textExtractor'>;
+export type EmbeddingGeneratorNodeType = Node<EmbeddingGeneratorNodeData, 'embeddingGenerator'>;
 
-export type AppNode = KafkaSourceNodeType | KafkaSinkNodeType | GeoIpNodeType | InspectorNodeType | MaterializedViewNodeType | TextExtractorNodeType;
+export type AppNode = KafkaSourceNodeType | KafkaSinkNodeType | GeoIpNodeType | InspectorNodeType | MaterializedViewNodeType | TextExtractorNodeType | EmbeddingGeneratorNodeType;
 
 export const nodeTypes: NodeTypes = {
   kafkaSource: KafkaSourceNode,
@@ -49,4 +57,5 @@ export const nodeTypes: NodeTypes = {
   inspector: InspectorNode,
   materializedView: MaterializedViewNode,
   textExtractor: TextExtractorNode,
+  embeddingGenerator: EmbeddingGeneratorNode,
 };

--- a/uiv2/src/generated/job_pb.ts
+++ b/uiv2/src/generated/job_pb.ts
@@ -850,6 +850,61 @@ export class TextExtractorNode extends Message<TextExtractorNode> {
 }
 
 /**
+ * @generated from message io.typestream.grpc.EmbeddingGeneratorNode
+ */
+export class EmbeddingGeneratorNode extends Message<EmbeddingGeneratorNode> {
+  /**
+   * Field containing text to embed
+   *
+   * @generated from field: string text_field = 1;
+   */
+  textField = "";
+
+  /**
+   * Output field name (default: embedding)
+   *
+   * @generated from field: string output_field = 2;
+   */
+  outputField = "";
+
+  /**
+   * OpenAI model (default: text-embedding-3-small)
+   *
+   * @generated from field: string model = 3;
+   */
+  model = "";
+
+  constructor(data?: PartialMessage<EmbeddingGeneratorNode>) {
+    super();
+    proto3.util.initPartial(data, this);
+  }
+
+  static readonly runtime: typeof proto3 = proto3;
+  static readonly typeName = "io.typestream.grpc.EmbeddingGeneratorNode";
+  static readonly fields: FieldList = proto3.util.newFieldList(() => [
+    { no: 1, name: "text_field", kind: "scalar", T: 9 /* ScalarType.STRING */ },
+    { no: 2, name: "output_field", kind: "scalar", T: 9 /* ScalarType.STRING */ },
+    { no: 3, name: "model", kind: "scalar", T: 9 /* ScalarType.STRING */ },
+  ]);
+
+  static fromBinary(bytes: Uint8Array, options?: Partial<BinaryReadOptions>): EmbeddingGeneratorNode {
+    return new EmbeddingGeneratorNode().fromBinary(bytes, options);
+  }
+
+  static fromJson(jsonValue: JsonValue, options?: Partial<JsonReadOptions>): EmbeddingGeneratorNode {
+    return new EmbeddingGeneratorNode().fromJson(jsonValue, options);
+  }
+
+  static fromJsonString(jsonString: string, options?: Partial<JsonReadOptions>): EmbeddingGeneratorNode {
+    return new EmbeddingGeneratorNode().fromJsonString(jsonString, options);
+  }
+
+  static equals(a: EmbeddingGeneratorNode | PlainMessage<EmbeddingGeneratorNode> | undefined, b: EmbeddingGeneratorNode | PlainMessage<EmbeddingGeneratorNode> | undefined): boolean {
+    return proto3.util.equals(EmbeddingGeneratorNode, a, b);
+  }
+}
+
+/**
  * @generated from message io.typestream.grpc.PipelineNode
  */
 export class PipelineNode extends Message<PipelineNode> {
@@ -945,6 +1000,12 @@ export class PipelineNode extends Message<PipelineNode> {
      */
     value: TextExtractorNode;
     case: "textExtractor";
+  } | {
+    /**
+     * @generated from field: io.typestream.grpc.EmbeddingGeneratorNode embedding_generator = 16;
+     */
+    value: EmbeddingGeneratorNode;
+    case: "embeddingGenerator";
   } | { case: undefined; value?: undefined } = { case: undefined };
 
   constructor(data?: PartialMessage<PipelineNode>) {
@@ -970,6 +1031,7 @@ export class PipelineNode extends Message<PipelineNode> {
     { no: 13, name: "inspector", kind: "message", T: InspectorNode, oneof: "node_type" },
     { no: 14, name: "reduce_latest", kind: "message", T: ReduceLatestNode, oneof: "node_type" },
     { no: 15, name: "text_extractor", kind: "message", T: TextExtractorNode, oneof: "node_type" },
+    { no: 16, name: "embedding_generator", kind: "message", T: EmbeddingGeneratorNode, oneof: "node_type" },
   ]);
 
   static fromBinary(bytes: Uint8Array, options?: Partial<BinaryReadOptions>): PipelineNode {

--- a/uiv2/src/utils/graphSerializer.ts
+++ b/uiv2/src/utils/graphSerializer.ts
@@ -9,11 +9,12 @@ import {
   DataStreamProto,
   GeoIpNode as GeoIpNodeProto,
   TextExtractorNode as TextExtractorNodeProto,
+  EmbeddingGeneratorNode as EmbeddingGeneratorNodeProto,
   GroupNode,
   CountNode,
   ReduceLatestNode,
 } from '../generated/job_pb';
-import type { KafkaSourceNodeData, KafkaSinkNodeData, GeoIpNodeData, InspectorNodeData, MaterializedViewNodeData, TextExtractorNodeData } from '../components/graph-builder/nodes';
+import type { KafkaSourceNodeData, KafkaSinkNodeData, GeoIpNodeData, InspectorNodeData, MaterializedViewNodeData, TextExtractorNodeData, EmbeddingGeneratorNodeData } from '../components/graph-builder/nodes';
 
 export function serializeGraph(nodes: Node[], edges: Edge[]): PipelineGraph {
   const pipelineNodes: PipelineNode[] = [];
@@ -121,6 +122,22 @@ export function serializeGraph(nodes: Node[], edges: Edge[]): PipelineGraph {
           value: new TextExtractorNodeProto({
             filePathField: data.filePathField,
             outputField: data.outputField || 'text',
+          }),
+        },
+      }));
+      return;
+    }
+
+    if (node.type === 'embeddingGenerator') {
+      const data = node.data as EmbeddingGeneratorNodeData;
+      pipelineNodes.push(new PipelineNode({
+        id: node.id,
+        nodeType: {
+          case: 'embeddingGenerator',
+          value: new EmbeddingGeneratorNodeProto({
+            textField: data.textField,
+            outputField: data.outputField || 'embedding',
+            model: data.model || 'text-embedding-3-small',
           }),
         },
       }));


### PR DESCRIPTION
## Summary

Adds an `EmbeddingGenerator` node that generates vector embeddings from text fields using OpenAI's embedding API. This enables building pipelines that produce embeddings for downstream vector database storage.

- Add `EmbeddingGeneratorService` - OpenAI HTTP client for embedding generation
- Add `EmbeddingGeneratorNodeHandler` - Proto conversion and type inference
- Add `EmbeddingGeneratorExecution` - Kafka Streams and Shell runtime execution
- Add `EmbeddingGenerator` to Node sealed interface
- Add `EmbeddingGeneratorNode` proto message
- Add UI component for EmbeddingGenerator node in graph builder
- Add type inference rule producing `List<Float>` schema for embedding vectors
- Support configurable text field, output field name, and model selection
- Load OpenAI API key from `OPENAI_API_KEY` environment variable (via `.env` file)
- Limit FileUploadsConnector to 50 messages to control embedding API costs during testing

### Configuration
| Parameter | Default | Description |
|-----------|---------|-------------|
| `text_field` | (required) | Field containing text to embed |
| `output_field` | `embedding` | Output field name for vector |
| `model` | `text-embedding-3-small` | OpenAI embedding model |

Closes #164

## Test plan
- [x] Unit tests pass for TypeRules, EmbeddingGeneratorService
- [x] Server compiles and starts successfully
- [x] UI builds without errors
- [x] Manual test: Created pipeline with EmbeddingGenerator node
- [x] Verified embedding vectors appear in output topic (1536 floats per record)