### PR TITLE
feat: Add field types to schema inference with UI enhancements

### DIFF
--- a/protos/src/main/proto/job.proto
+++ b/protos/src/main/proto/job.proto
@@ -241,10 +241,16 @@ message InferGraphSchemasResponse {
   map<string, NodeSchemaResult> schemas = 1;
 }
 
+message SchemaField {
+  string name = 1;
+  string type = 2;
+}
+
 message NodeSchemaResult {
   repeated string fields = 1;
-  string encoding = 2;
-  string error = 3;
+  repeated SchemaField typed_fields = 2;
+  string encoding = 3;
+  string error = 4;
 }
 
 // OpenAI models listing

--- a/uiv2/src/components/graph-builder/GraphBuilder.tsx
+++ b/uiv2/src/components/graph-builder/GraphBuilder.tsx
@@ -83,11 +83,15 @@ export function GraphBuilder() {
         setNodes((nds) =>
           nds.map((n) => {
             const result = response.schemas[n.id];
+            // Use typed_fields for full type info, with fields as fallback for backward compat
+            const outputSchema = result?.typedFields?.length
+              ? result.typedFields.map(f => ({ name: f.name, type: f.type }))
+              : result?.fields?.map(name => ({ name, type: 'Unknown' })) ?? [];
             return {
               ...n,
               data: {
                 ...n.data,
-                outputSchema: result?.fields ?? [],
+                outputSchema,
                 schemaError: result?.error || undefined,
                 isInferring: false,
               },

--- a/uiv2/src/components/graph-builder/nodes/BaseNode.tsx
+++ b/uiv2/src/components/graph-builder/nodes/BaseNode.tsx
@@ -4,17 +4,20 @@ import Box from '@mui/material/Box';
 import CircularProgress from '@mui/material/CircularProgress';
 import Tooltip from '@mui/material/Tooltip';
 import ErrorOutlineIcon from '@mui/icons-material/ErrorOutline';
+import InfoOutlinedIcon from '@mui/icons-material/InfoOutlined';
 import type { ReactNode } from 'react';
+import type { SchemaField } from './index';
 
 interface BaseNodeProps {
   title: string;
   icon?: ReactNode;
   error?: string;
   isInferring?: boolean;
+  outputSchema?: SchemaField[];
   children: ReactNode;
 }
 
-export function BaseNode({ title, icon, error, isInferring, children }: BaseNodeProps) {
+export function BaseNode({ title, icon, error, isInferring, outputSchema, children }: BaseNodeProps) {
   return (
     <Paper
       elevation={3}
@@ -44,6 +47,23 @@ export function BaseNode({ title, icon, error, isInferring, children }: BaseNode
           {title}
         </Typography>
         {isInferring && <CircularProgress size={14} />}
+        {outputSchema && outputSchema.length > 0 && (
+          <Tooltip
+            title={
+              <Box>
+                <Typography variant="caption" fontWeight="bold">Output Schema</Typography>
+                {outputSchema.map(f => (
+                  <Typography key={f.name} variant="caption" display="block" sx={{ fontFamily: 'monospace' }}>
+                    {f.name}: {f.type}
+                  </Typography>
+                ))}
+              </Box>
+            }
+            arrow
+          >
+            <InfoOutlinedIcon fontSize="small" sx={{ cursor: 'help', opacity: 0.6 }} />
+          </Tooltip>
+        )}
         {error && (
           <Tooltip title={error} arrow>
             <ErrorOutlineIcon color="error" fontSize="small" />

--- a/uiv2/src/components/graph-builder/nodes/GeoIpNode.tsx
+++ b/uiv2/src/components/graph-builder/nodes/GeoIpNode.tsx
@@ -1,12 +1,14 @@
+import { useEffect } from 'react';
 import { Handle, Position, useReactFlow, useNodes, useEdges, type NodeProps } from '@xyflow/react';
 import FormControl from '@mui/material/FormControl';
 import InputLabel from '@mui/material/InputLabel';
 import Select from '@mui/material/Select';
 import MenuItem from '@mui/material/MenuItem';
 import TextField from '@mui/material/TextField';
+import Typography from '@mui/material/Typography';
 import PublicIcon from '@mui/icons-material/Public';
 import { BaseNode } from './BaseNode';
-import type { GeoIpNodeType, NodeValidationState } from './index';
+import { isTypeCompatible, type GeoIpNodeType, type NodeValidationState } from './index';
 
 /** Node role determines handle configuration: sources have no input, sinks have no output */
 export const geoIpRole = 'transform' as const;
@@ -26,6 +28,16 @@ export function GeoIpNode({ id, data }: NodeProps<GeoIpNodeType>) {
   const upstreamData = upstreamNode?.data as NodeValidationState | undefined;
   const fields = upstreamData?.outputSchema ?? [];
 
+  // Get compatible fields for auto-selection (IP field should be string type)
+  const compatibleFields = fields.filter(f => isTypeCompatible(f.type, 'string'));
+
+  // Auto-select first compatible field when schema loads and no field is selected
+  useEffect(() => {
+    if (!data.ipField && compatibleFields.length > 0) {
+      updateNodeData(id, { ipField: compatibleFields[0].name });
+    }
+  }, [data.ipField, compatibleFields, id, updateNodeData]);
+
   return (
     <>
       <Handle type="target" position={Position.Left} />
@@ -34,6 +46,7 @@ export function GeoIpNode({ id, data }: NodeProps<GeoIpNodeType>) {
         icon={<PublicIcon fontSize="small" />}
         error={data.schemaError}
         isInferring={data.isInferring}
+        outputSchema={data.outputSchema}
       >
         <FormControl fullWidth size="small" className="nodrag nowheel" sx={{ mb: 1.5 }}>
           <InputLabel>IP Field</InputLabel>
@@ -43,11 +56,22 @@ export function GeoIpNode({ id, data }: NodeProps<GeoIpNodeType>) {
             onChange={(e) => updateNodeData(id, { ipField: e.target.value })}
             disabled={data.isInferring || fields.length === 0}
           >
-            {fields.map((field) => (
-              <MenuItem key={field} value={field}>
-                {field}
-              </MenuItem>
-            ))}
+            {fields.map((field) => {
+              const compatible = isTypeCompatible(field.type, 'string');
+              return (
+                <MenuItem
+                  key={field.name}
+                  value={field.name}
+                  disabled={!compatible}
+                  sx={{ opacity: compatible ? 1 : 0.5 }}
+                >
+                  {field.name}
+                  <Typography component="span" color="text.secondary" sx={{ ml: 1, fontSize: '0.75rem' }}>
+                    ({field.type})
+                  </Typography>
+                </MenuItem>
+              );
+            })}
           </Select>
         </FormControl>
         <TextField

--- a/uiv2/src/components/graph-builder/nodes/InspectorNode.tsx
+++ b/uiv2/src/components/graph-builder/nodes/InspectorNode.tsx
@@ -21,6 +21,7 @@ export function InspectorNode({ id, data }: NodeProps<InspectorNodeType>) {
         icon={<VisibilityIcon fontSize="small" />}
         error={data.schemaError}
         isInferring={data.isInferring}
+        outputSchema={data.outputSchema}
       >
         <Button
           fullWidth

--- a/uiv2/src/components/graph-builder/nodes/KafkaSinkNode.tsx
+++ b/uiv2/src/components/graph-builder/nodes/KafkaSinkNode.tsx
@@ -18,6 +18,7 @@ export function KafkaSinkNode({ id, data }: NodeProps<KafkaSinkNodeType>) {
         icon={<OutputIcon fontSize="small" />}
         error={data.schemaError}
         isInferring={data.isInferring}
+        outputSchema={data.outputSchema}
       >
         <TextField
           fullWidth

--- a/uiv2/src/components/graph-builder/nodes/KafkaSourceNode.tsx
+++ b/uiv2/src/components/graph-builder/nodes/KafkaSourceNode.tsx
@@ -46,6 +46,7 @@ export function KafkaSourceNode({ id, data }: NodeProps<KafkaSourceNodeType>) {
         icon={<InputIcon fontSize="small" />}
         error={data.schemaError}
         isInferring={data.isInferring}
+        outputSchema={data.outputSchema}
       >
         <FormControl fullWidth size="small" className="nodrag nowheel">
           <InputLabel>Topic</InputLabel>

--- a/uiv2/src/components/graph-builder/nodes/MaterializedViewNode.tsx
+++ b/uiv2/src/components/graph-builder/nodes/MaterializedViewNode.tsx
@@ -1,8 +1,10 @@
+import { useEffect } from 'react';
 import { Handle, Position, useReactFlow, useNodes, useEdges, type NodeProps } from '@xyflow/react';
 import FormControl from '@mui/material/FormControl';
 import InputLabel from '@mui/material/InputLabel';
 import Select from '@mui/material/Select';
 import MenuItem from '@mui/material/MenuItem';
+import Typography from '@mui/material/Typography';
 import TableChartIcon from '@mui/icons-material/TableChart';
 import { BaseNode } from './BaseNode';
 import type { MaterializedViewNodeType, NodeValidationState } from './index';
@@ -27,6 +29,13 @@ export function MaterializedViewNode({ id, data }: NodeProps<MaterializedViewNod
   const upstreamData = upstreamNode?.data as NodeValidationState | undefined;
   const fields = upstreamData?.outputSchema ?? [];
 
+  // Auto-select first field when schema loads and no field is selected
+  useEffect(() => {
+    if (!data.groupByField && fields.length > 0) {
+      updateNodeData(id, { groupByField: fields[0].name });
+    }
+  }, [data.groupByField, fields, id, updateNodeData]);
+
   return (
     <>
       <Handle type="target" position={Position.Left} />
@@ -35,6 +44,7 @@ export function MaterializedViewNode({ id, data }: NodeProps<MaterializedViewNod
         icon={<TableChartIcon fontSize="small" />}
         error={data.schemaError}
         isInferring={data.isInferring}
+        outputSchema={data.outputSchema}
       >
         <FormControl fullWidth size="small" className="nodrag nowheel" sx={{ mb: 1.5 }}>
           <InputLabel>Aggregation</InputLabel>
@@ -56,8 +66,11 @@ export function MaterializedViewNode({ id, data }: NodeProps<MaterializedViewNod
             disabled={data.isInferring || fields.length === 0}
           >
             {fields.map((field) => (
-              <MenuItem key={field} value={field}>
-                {field}
+              <MenuItem key={field.name} value={field.name}>
+                {field.name}
+                <Typography component="span" color="text.secondary" sx={{ ml: 1, fontSize: '0.75rem' }}>
+                  ({field.type})
+                </Typography>
               </MenuItem>
             ))}
           </Select>

--- a/uiv2/src/components/graph-builder/nodes/OpenAiTransformerNode.tsx
+++ b/uiv2/src/components/graph-builder/nodes/OpenAiTransformerNode.tsx
@@ -25,6 +25,7 @@ export function OpenAiTransformerNode({ id, data }: NodeProps<OpenAiTransformerN
         icon={<AutoAwesomeIcon fontSize="small" />}
         error={data.schemaError}
         isInferring={data.isInferring}
+        outputSchema={data.outputSchema}
       >
         <FormControl fullWidth size="small" className="nodrag nowheel" sx={{ mb: 1.5 }}>
           <InputLabel>Model</InputLabel>

--- a/uiv2/src/components/graph-builder/nodes/TextExtractorNode.tsx
+++ b/uiv2/src/components/graph-builder/nodes/TextExtractorNode.tsx
@@ -1,12 +1,14 @@
+import { useEffect } from 'react';
 import { Handle, Position, useReactFlow, useNodes, useEdges, type NodeProps } from '@xyflow/react';
 import FormControl from '@mui/material/FormControl';
 import InputLabel from '@mui/material/InputLabel';
 import Select from '@mui/material/Select';
 import MenuItem from '@mui/material/MenuItem';
 import TextField from '@mui/material/TextField';
+import Typography from '@mui/material/Typography';
 import DescriptionIcon from '@mui/icons-material/Description';
 import { BaseNode } from './BaseNode';
-import type { TextExtractorNodeType, NodeValidationState } from './index';
+import { isTypeCompatible, type TextExtractorNodeType, type NodeValidationState } from './index';
 
 /** Node role determines handle configuration: sources have no input, sinks have no output */
 export const textExtractorRole = 'transform' as const;
@@ -26,6 +28,16 @@ export function TextExtractorNode({ id, data }: NodeProps<TextExtractorNodeType>
   const upstreamData = upstreamNode?.data as NodeValidationState | undefined;
   const fields = upstreamData?.outputSchema ?? [];
 
+  // Get compatible fields for auto-selection (file path should be string type)
+  const compatibleFields = fields.filter(f => isTypeCompatible(f.type, 'string'));
+
+  // Auto-select first compatible field when schema loads and no field is selected
+  useEffect(() => {
+    if (!data.filePathField && compatibleFields.length > 0) {
+      updateNodeData(id, { filePathField: compatibleFields[0].name });
+    }
+  }, [data.filePathField, compatibleFields, id, updateNodeData]);
+
   return (
     <>
       <Handle type="target" position={Position.Left} />
@@ -34,6 +46,7 @@ export function TextExtractorNode({ id, data }: NodeProps<TextExtractorNodeType>
         icon={<DescriptionIcon fontSize="small" />}
         error={data.schemaError}
         isInferring={data.isInferring}
+        outputSchema={data.outputSchema}
       >
         <FormControl fullWidth size="small" className="nodrag nowheel" sx={{ mb: 1.5 }}>
           <InputLabel>File Path Field</InputLabel>
@@ -43,11 +56,22 @@ export function TextExtractorNode({ id, data }: NodeProps<TextExtractorNodeType>
             onChange={(e) => updateNodeData(id, { filePathField: e.target.value })}
             disabled={data.isInferring || fields.length === 0}
           >
-            {fields.map((field) => (
-              <MenuItem key={field} value={field}>
-                {field}
-              </MenuItem>
-            ))}
+            {fields.map((field) => {
+              const compatible = isTypeCompatible(field.type, 'string');
+              return (
+                <MenuItem
+                  key={field.name}
+                  value={field.name}
+                  disabled={!compatible}
+                  sx={{ opacity: compatible ? 1 : 0.5 }}
+                >
+                  {field.name}
+                  <Typography component="span" color="text.secondary" sx={{ ml: 1, fontSize: '0.75rem' }}>
+                    ({field.type})
+                  </Typography>
+                </MenuItem>
+              );
+            })}
           </Select>
         </FormControl>
         <TextField

--- a/uiv2/src/generated/job_pb.ts
+++ b/uiv2/src/generated/job_pb.ts
@@ -1890,6 +1890,49 @@ export class InferGraphSchemasResponse extends Message<InferGraphSchemasResponse
 }
 
 /**
+ * @generated from message io.typestream.grpc.SchemaField
+ */
+export class SchemaField extends Message<SchemaField> {
+  /**
+   * @generated from field: string name = 1;
+   */
+  name = "";
+
+  /**
+   * @generated from field: string type = 2;
+   */
+  type = "";
+
+  constructor(data?: PartialMessage<SchemaField>) {
+    super();
+    proto3.util.initPartial(data, this);
+  }
+
+  static readonly runtime: typeof proto3 = proto3;
+  static readonly typeName = "io.typestream.grpc.SchemaField";
+  static readonly fields: FieldList = proto3.util.newFieldList(() => [
+    { no: 1, name: "name", kind: "scalar", T: 9 /* ScalarType.STRING */ },
+    { no: 2, name: "type", kind: "scalar", T: 9 /* ScalarType.STRING */ },
+  ]);
+
+  static fromBinary(bytes: Uint8Array, options?: Partial<BinaryReadOptions>): SchemaField {
+    return new SchemaField().fromBinary(bytes, options);
+  }
+
+  static fromJson(jsonValue: JsonValue, options?: Partial<JsonReadOptions>): SchemaField {
+    return new SchemaField().fromJson(jsonValue, options);
+  }
+
+  static fromJsonString(jsonString: string, options?: Partial<JsonReadOptions>): SchemaField {
+    return new SchemaField().fromJsonString(jsonString, options);
+  }
+
+  static equals(a: SchemaField | PlainMessage<SchemaField> | undefined, b: SchemaField | PlainMessage<SchemaField> | undefined): boolean {
+    return proto3.util.equals(SchemaField, a, b);
+  }
+}
+
+/**
  * @generated from message io.typestream.grpc.NodeSchemaResult
  */
 export class NodeSchemaResult extends Message<NodeSchemaResult> {
@@ -1899,12 +1942,17 @@ export class NodeSchemaResult extends Message<NodeSchemaResult> {
   fields: string[] = [];
 
   /**
-   * @generated from field: string encoding = 2;
+   * @generated from field: repeated io.typestream.grpc.SchemaField typed_fields = 2;
+   */
+  typedFields: SchemaField[] = [];
+
+  /**
+   * @generated from field: string encoding = 3;
    */
   encoding = "";
 
   /**
-   * @generated from field: string error = 3;
+   * @generated from field: string error = 4;
    */
   error = "";
 
@@ -1917,8 +1965,9 @@ export class NodeSchemaResult extends Message<NodeSchemaResult> {
   static readonly typeName = "io.typestream.grpc.NodeSchemaResult";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "fields", kind: "scalar", T: 9 /* ScalarType.STRING */, repeated: true },
-    { no: 2, name: "encoding", kind: "scalar", T: 9 /* ScalarType.STRING */ },
-    { no: 3, name: "error", kind: "scalar", T: 9 /* ScalarType.STRING */ },
+    { no: 2, name: "typed_fields", kind: "message", T: SchemaField, repeated: true },
+    { no: 3, name: "encoding", kind: "scalar", T: 9 /* ScalarType.STRING */ },
+    { no: 4, name: "error", kind: "scalar", T: 9 /* ScalarType.STRING */ },
   ]);
 
   static fromBinary(bytes: Uint8Array, options?: Partial<BinaryReadOptions>): NodeSchemaResult {

--- a/uiv2/src/utils/graphDependencyKey.test.ts
+++ b/uiv2/src/utils/graphDependencyKey.test.ts
@@ -35,7 +35,7 @@ describe('getGraphDependencyKey', () => {
         position: { x: 0, y: 0 },
         data: {
           topicPath: '/dev/kafka/local/topics/web_visits',
-          outputSchema: ['ip', 'url', 'timestamp'],
+          outputSchema: [{ name: 'ip', type: 'String' }, { name: 'url', type: 'String' }, { name: 'timestamp', type: 'Long' }],
           schemaError: undefined,
           isInferring: false,
         },
@@ -123,7 +123,7 @@ describe('getGraphDependencyKey', () => {
         data: {
           topicPath: '/dev/kafka/local/topics/web_visits',
           isInferring: false, // Done inferring
-          outputSchema: ['ip', 'url'],
+          outputSchema: [{ name: 'ip', type: 'String' }, { name: 'url', type: 'String' }],
         },
       },
     ];


### PR DESCRIPTION
## Summary

- Extended schema inference to include field types (not just names)
- Added tooltip on nodes showing output schema with types (hover over info icon in node header)
- Grey out incompatible fields in dropdowns based on type requirements
- Auto-select first compatible field when node is added

## Changes

### Proto & Server
- Added `SchemaField` message with `name` and `type` fields
- Server now populates `typed_fields` using `Schema.printTypes()` (e.g., "String", "Long", "Optional<DateTime>")

### UI
- Info icon tooltip on all nodes showing output schema with types
- Field dropdowns now show type in parentheses: `ip (String)`
- Incompatible fields are greyed out (e.g., non-string fields for GeoIP lookup)
- First compatible field auto-selected when node is added

## Test plan
- [ ] Create a graph with KafkaSource → GeoIp
- [ ] Verify tooltip on KafkaSource shows output fields with types
- [ ] Verify GeoIp dropdown shows field types in parentheses
- [ ] Verify non-string fields are greyed out in ipField dropdown
- [ ] Verify first compatible field is auto-selected when GeoIp node is added