### PR TITLE
fix: Add HTTP timeouts to Kafka Connect connector creation

### DIFF
--- a/server/src/main/kotlin/io/typestream/server/ConnectionService.kt
+++ b/server/src/main/kotlin/io/typestream/server/ConnectionService.kt
@@ -542,6 +542,8 @@ class ConnectionService : ConnectionServiceGrpcKt.ConnectionServiceCoroutineImpl
         val connection = url.openConnection() as java.net.HttpURLConnection
 
         try {
+            connection.connectTimeout = 10000
+            connection.readTimeout = 30000
             connection.requestMethod = "POST"
             connection.setRequestProperty("Content-Type", "application/json")
             connection.doOutput = true


### PR DESCRIPTION
## Summary
- Adds explicit `connectTimeout` (10s) and `readTimeout` (30s) to Kafka Connect HTTP calls
- Prevents indefinite hangs when Kafka Connect is unreachable
- Addresses reliability concern from code review (typestream-dye)

## Changes
- `server/src/main/kotlin/io/typestream/server/ConnectionService.kt`: Added timeout configuration to `createKafkaConnectConnector()`

## Test plan
- [x] Unit tests pass (209 passing)
- [ ] Integration tests require Docker (expected to fail in CI containers)