### PR TITLE
fix: make footer year dynamic

### DIFF
--- a/website/src/partials/footer/footer.html
+++ b/website/src/partials/footer/footer.html
@@ -68,7 +68,7 @@
     <div class="container relative text-center pl-10">
       <div class="grid md:grid-cols-2 items-center gap-[30px]">
         <div class="md:text-start text-center">
-          <p class="mb-0">© 2023 TypeStream.</p>
+          <p class="mb-0">© {{currentYear}} TypeStream.</p>
         </div>
       </div>
     </div>

--- a/website/vite.config.js
+++ b/website/vite.config.js
@@ -23,6 +23,9 @@ export default defineConfig({
   plugins: [
     handlebars({
       partialDirectory: resolve(__dirname, "src/partials"),
+      context: {
+        currentYear: new Date().getFullYear(),
+      },
     }),
   ],
   css: {


### PR DESCRIPTION
Updated the footer copyright year to be dynamically generated using the current year instead of a hardcoded 2023 value.

Closes #214

Generated with [Claude Code](https://claude.ai/claude-code)