### PR TITLE
feat(docker): publish UI image to GHCR for auto-updates

### DIFF
--- a/.github/workflows/publish-images.yml
+++ b/.github/workflows/publish-images.yml
@@ -171,11 +171,61 @@ jobs:
           path: /tmp/kafka-connect-image.tar.gz
           retention-days: 1
 
+  # Build and test UI
+  build-and-test-ui:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build UI image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: uiv2/Dockerfile
+          load: true
+          tags: ui:test
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Smoke test - UI serves content
+        run: |
+          docker run -d --name ui-smoke-test -p 5173:5173 ui:test
+          echo "Waiting for UI to start..."
+          for i in {1..15}; do
+            if curl -sf http://localhost:5173 > /dev/null 2>&1; then
+              echo "UI is serving content"
+              break
+            fi
+            if [ $i -eq 15 ]; then
+              echo "UI failed to start in time"
+              docker logs ui-smoke-test
+              exit 1
+            fi
+            sleep 1
+          done
+          docker stop ui-smoke-test
+          docker rm ui-smoke-test
+          echo "Smoke test passed!"
+
+      - name: Save UI image for publishing
+        run: docker save ui:test | gzip > /tmp/ui-image.tar.gz
+
+      - name: Upload UI image artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ui-image
+          path: /tmp/ui-image.tar.gz
+          retention-days: 1
+
   # Publish all images after smoke tests pass
   publish-images:
     runs-on: ubuntu-latest
     timeout-minutes: 15
-    needs: [build-and-test-server, build-and-test-demo-data, build-and-test-kafka-connect]
+    needs: [build-and-test-server, build-and-test-demo-data, build-and-test-kafka-connect, build-and-test-ui]
     permissions:
       contents: read
       packages: write
@@ -251,6 +301,26 @@ jobs:
         run: |
           echo '${{ steps.kafka-connect-meta.outputs.tags }}' | while IFS= read -r tag; do
             [ -n "$tag" ] && docker tag kafka-connect:test "$tag" && docker push "$tag"
+          done
+
+      # UI
+      - name: Load UI image
+        run: gunzip -c /tmp/images/ui-image/ui-image.tar.gz | docker load
+
+      - name: Extract UI metadata
+        id: ui-meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/typestreamio/ui
+          tags: |
+            type=semver,pattern={{version}}
+            type=sha,prefix=
+            type=raw,value=latest,enable=${{ github.ref_type == 'tag' }}
+
+      - name: Tag and push UI image
+        run: |
+          echo '${{ steps.ui-meta.outputs.tags }}' | while IFS= read -r tag; do
+            [ -n "$tag" ] && docker tag ui:test "$tag" && docker push "$tag"
           done
 
   # Create GitHub Release after images are published (only on tag push)

--- a/docker-compose.demo.yml
+++ b/docker-compose.demo.yml
@@ -49,14 +49,11 @@ services:
     labels:
       - "com.centurylinklabs.watchtower.enable=true"
 
-  # React frontend - production build served by Caddy
-  # TODO: publish uiv2 to GHCR to avoid building from source
+  # React frontend - pre-built image from GHCR
   uiv2:
-    build:
-      context: .
-      dockerfile: uiv2/Dockerfile
-      args:
-        - VITE_API_URL=
+    image: ghcr.io/typestreamio/ui:${TYPESTREAM_VERSION:-latest}
+    labels:
+      - "com.centurylinklabs.watchtower.enable=true"
     networks:
       - typestream_network
     depends_on:


### PR DESCRIPTION
## Summary
- Add `build-and-test-ui` job to the publish-images workflow that builds `uiv2/Dockerfile`, smoke tests that Caddy serves content, and publishes to `ghcr.io/typestreamio/ui`
- Update `docker-compose.demo.yml` to use the GHCR image instead of building from source, with Watchtower label for automatic updates
- Removes the TODO comment about publishing uiv2 to GHCR

## Test plan
- [ ] Trigger workflow via `workflow_dispatch` or tag push and verify `ghcr.io/typestreamio/ui:latest` is published
- [ ] On demo server, verify Watchtower picks up the new `ui` image and restarts the container