### PR TITLE
docs: rebuild architecture documentation tree

### DIFF
--- a/.claude/hooks/post-task-checks.sh
+++ b/.claude/hooks/post-task-checks.sh
@@ -70,4 +70,19 @@ if [ "$BACKEND_CHANGED" = true ]; then
     echo "✅ Backend checks passed!"
 fi
 
+# Architecture doc staleness check (advisory only, does not block)
+ARCH_COMPONENTS=("server" "uiv2" "cli" "protos" "connectors/demo-data")
+for component in "${ARCH_COMPONENTS[@]}"; do
+    COMPONENT_CHANGED=false
+    ARCH_CHANGED=false
+    while IFS= read -r file; do
+        [[ "$file" == ${component}/* ]] && COMPONENT_CHANGED=true
+        [[ "$file" == "${component}/ARCHITECTURE.md" ]] && ARCH_CHANGED=true
+    done <<< "$MODIFIED_FILES"
+    if [ "$COMPONENT_CHANGED" = true ] && [ "$ARCH_CHANGED" = false ]; then
+        echo "NOTE: ${component}/ changed but ${component}/ARCHITECTURE.md was not updated."
+        echo "Consider running: /upsert-architecture-with-repomix ${component}"
+    fi
+done
+
 exit 0

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,0 +1,279 @@
+# TypeStream Architecture
+
+TypeStream is a streaming data platform that compiles visual or text-based pipeline definitions into Kafka Streams topologies. It provides a UNIX-like abstraction over Kafka topics, a visual graph builder, and declarative pipeline-as-code management.
+
+## System Architecture
+
+```
+                           ┌──────────────────┐
+                           │    React UI       │ :80 (Caddy)
+                           │  (Graph Builder)  │
+                           └────────┬─────────┘
+                                    │ Connect Protocol (gRPC-Web)
+                           ┌────────┴─────────┐
+                           │     Envoy         │ :8080
+                           │  (gRPC-Web Proxy) │
+                           └────────┬─────────┘
+              ┌─────────────────────┼──────────────────────┐
+              │ gRPC :4242          │                       │
+     ┌────────┴─────────┐ ┌────────┴─────────┐   ┌────────┴─────────┐
+     │    Go CLI         │ │  TypeStream      │   │  Kafka Connect   │ :8083
+     │  (Cobra + gRPC)   │ │  Server (Kotlin) │   │  (Debezium +     │
+     └──────────────────┘ │                   │   │   JDBC/Weaviate)  │
+                          └────────┬─────────┘   └────────┬─────────┘
+                                   │                       │
+              ┌────────────────────┼───────────────────────┤
+              │                    │                        │
+     ┌────────┴─────────┐ ┌───────┴──────────┐  ┌────────┴─────────┐
+     │    Redpanda       │ │ Schema Registry   │  │   PostgreSQL     │
+     │  (Kafka broker)   │ │ (built into RP)   │  │  (CDC source)    │
+     │  :19092           │ │ :18081            │  │  :5432            │
+     └──────────────────┘ └──────────────────┘  └──────────────────┘
+```
+
+**Data path**: Sources (Kafka topics, CDC) → Server compiles pipeline → Kafka Streams topology → Sinks (Kafka topics, JDBC, Weaviate, Elasticsearch)
+
+**Control path**: UI/CLI → gRPC → Server → compiles, schedules, and monitors jobs
+
+## Component Overview
+
+| Directory | Purpose | Tech | Docs |
+|-----------|---------|------|------|
+| `server/` | Core platform: compiler, scheduler, gRPC services, Kafka Streams execution | Kotlin, Gradle, gRPC, Kafka Streams | [server/ARCHITECTURE.md](server/ARCHITECTURE.md) |
+| `uiv2/` | Visual pipeline builder and job dashboard | React 19, TypeScript, XYFlow, MUI | [uiv2/ARCHITECTURE.md](uiv2/ARCHITECTURE.md) |
+| `cli/` | Local dev environment, pipeline-as-code, interactive shell | Go, Cobra, gRPC, Docker Compose | [cli/ARCHITECTURE.md](cli/ARCHITECTURE.md) |
+| `protos/` | gRPC service contracts and data models (6 services) | Protocol Buffers | [protos/ARCHITECTURE.md](protos/ARCHITECTURE.md) |
+| `connectors/demo-data/` | Real-time data generators (Coinbase, Wikipedia, web visits, file uploads) | Kotlin, Avro, WebSocket/SSE | [connectors/demo-data/ARCHITECTURE.md](connectors/demo-data/ARCHITECTURE.md) |
+| `stub/` | Generated Kotlin/Java gRPC stubs from protos | Gradle protobuf plugin | -- |
+| `libs/testing/` | Shared test infrastructure (TestKafkaContainer, TestKafka helpers) | Kotlin, Testcontainers, Redpanda | -- |
+| `libs/k8s-client/` | Kubernetes client wrapper for K8s job execution | Kotlin, fabric8 | -- |
+| `libs/option/` | Functional option type | Kotlin | -- |
+| `config/` | Shared configuration (TOML parsing, KafkaConfig, GrpcConfig) | Kotlin | -- |
+| `tools/` | Development utilities | Kotlin | -- |
+| `buildSrc/` | Gradle convention plugins (`typestream.kotlin-conventions`) | Kotlin DSL | -- |
+| `docker/` | Envoy config, Caddyfile, Kafka Connect Dockerfile, postgres-init.sql | Docker, YAML | -- |
+| `scripts/` | Dev scripts (`dev/server.sh`, `dev/seed.sh`), release, deploy | Bash | -- |
+
+## Pipeline Lifecycle
+
+A pipeline goes from definition to execution through four possible entry points, all converging on a shared compilation and execution path.
+
+### Entry Points
+
+```
+  ┌─────────────────┐   ┌─────────────────┐   ┌─────────────────┐   ┌─────────────────┐
+  │  GUI             │   │  CLI Config      │   │  CLI Run         │   │  Interactive     │
+  │  (Graph Builder) │   │  (apply/plan)    │   │  (run command)   │   │  Shell (REPL)    │
+  └────────┬────────┘   └────────┬────────┘   └────────┬────────┘   └────────┬────────┘
+           │                      │                      │                      │
+  React Flow graph       .typestream.json        DSL source text        DSL source text
+           │                      │                      │                      │
+  serializeGraphWithSinks()  parsePipelineFile()         │                      │
+           │                      │                      │                      │
+  PipelineGraph proto    PipelineGraph proto     CreateJobRequest       RunProgramRequest
+           │                      │                      │                      │
+  CreateJobFromGraph     ApplyPipeline           CreateJob              RunProgram
+  (JobService gRPC)      (PipelineService gRPC)  (JobService gRPC)     (InteractiveSession gRPC)
+           │                      │                      │                      │
+           └──────────┬───────────┘                      └──────────┬───────────┘
+                      │                                              │
+              GraphCompiler.compile()                        Compiler.compile()
+              (proto → Graph<Node>)                  (text → Lexer → Parser → Interpreter
+                      │                                      → Graph<Node>)
+                      │                                              │
+                      └────────────────────┬─────────────────────────┘
+                                           │
+                                    Graph<Node> (validated)
+                                           │
+                                      Program (graph + metadata)
+                                           │
+                                    Scheduler.submit()
+                                           │
+                                    KafkaStreamsJob.start()
+                                           │
+                                    Kafka Streams topology running
+```
+
+### Compilation
+
+**Proto path** (`GraphCompiler`): Receives a `PipelineGraph` proto (from UI or config files). Each `PipelineNode` is resolved against the virtual filesystem to bind schemas, then converted to the corresponding `Node` sealed class. Schema inference runs through the graph.
+
+**Text path** (`Compiler`): Parses TypeStream DSL through Lexer → Parser → AST → Interpreter. The Interpreter binds types and builds a `Graph<Node>`. When possible, it also emits a `PipelineGraph` proto via `PipelineGraphEmitter` for persistence.
+
+Both paths produce a validated `Graph<Node>` wrapped in a `Program`.
+
+### Execution
+
+The `Scheduler` receives a `Program` and creates a `KafkaStreamsJob`:
+
+1. `buildTopology()` walks the node graph and maps each `Node` to Kafka Streams operators
+2. `KafkaStreams` instance is started with the topology
+3. Job state is tracked: `STARTING → RUNNING → STOPPING → STOPPED` (or `FAILED`)
+4. Output is available via a `-stdout` topic for streaming results
+
+### Persistence (Pipeline-as-Code)
+
+Named pipelines are persisted to a Kafka compacted topic (`__typestream_pipelines`):
+
+- **Key**: pipeline name (string)
+- **Value**: JSON-serialized record containing `PipelineMetadata` + `PipelineGraph` proto + `appliedAt` timestamp
+- **Tombstones**: `null` value for deletions
+
+On server startup, `PipelineStateStore.load()` consumes the entire topic, and `PipelineService.recoverPipelines()` recompiles and restarts each pipeline.
+
+### Preview
+
+Inspector nodes tap the stream without altering data flow. The UI uses `CreatePreviewJob` → `StreamPreview` (server-sent stream) to show live data in the graph builder.
+
+## Node Reference
+
+The server implements 18 node types as a Kotlin sealed interface (`Node.kt`). Each node encapsulates its own schema transformation via `inferOutputSchema()`.
+
+### Source Nodes
+
+| Node | Config | Schema Behavior |
+|------|--------|----------------|
+| **StreamSource** | `dataStream`, `encoding`, `unwrapCdc` | Looks up schema from Schema Registry via catalog. If `unwrapCdc=true`, extracts the `after` payload from CDC envelope. |
+| **ShellSource** | `data` (list of DataStreams) | Uses first data stream's schema. Always JSON encoding. |
+
+### Transform Nodes
+
+| Node | Config | Schema Behavior |
+|------|--------|----------------|
+| **Filter** | `byKey`, `predicate` | Pass-through (schema unchanged) |
+| **Map** | `mapper` expression | Pass-through (TODO: extract field transforms for accurate typing) |
+| **Group** | `keyMapper` expression | Pass-through (re-keys records for downstream aggregation) |
+| **Join** | `with` stream, `joinType` | Merges left and right schemas into a combined struct |
+| **Each** | `fn` expression | Pass-through (side-effect only) |
+| **NoOp** | _(none)_ | Pass-through (structural placeholder, root node) |
+
+### Aggregation Nodes
+
+| Node | Config | Schema Behavior |
+|------|--------|----------------|
+| **Count** | _(none)_ | Pass-through (counts into a KTable) |
+| **WindowedCount** | `windowSizeSeconds` | Pass-through (tumbling window count) |
+| **ReduceLatest** | _(none)_ | Pass-through (keeps latest value per key) |
+
+### Enrichment Nodes
+
+| Node | Config | Schema Behavior |
+|------|--------|----------------|
+| **GeoIp** | `ipField`, `outputField` | Adds `outputField` (string) to schema. Validates `ipField` exists. |
+| **TextExtractor** | `filePathField`, `outputField` | Adds `outputField` (string) to schema. Validates `filePathField` exists. |
+| **EmbeddingGenerator** | `textField`, `outputField`, `model` | Adds `outputField` (list of floats) to schema. Validates `textField` exists. |
+| **OpenAiTransformer** | `prompt`, `outputField`, `model` | Adds `outputField` (string) to schema. |
+
+### Sink / Inspection Nodes
+
+| Node | Config | Schema Behavior |
+|------|--------|----------------|
+| **Sink** | `output` topic, `encoding` | Copies input schema to output path |
+| **Inspector** | `label` | Pass-through (taps stream for preview/debugging) |
+
+## Schema Propagation
+
+Schema inference is a compile-time pass that flows output schemas through the pipeline graph. It enables the UI to show field names on every edge and validate node configurations before execution.
+
+**How it works:**
+
+1. Source nodes resolve their schema from Schema Registry (via the virtual filesystem catalog)
+2. Each downstream node's `inferOutputSchema()` receives the upstream `DataStream` and `Encoding`
+3. Most nodes pass the schema through unchanged (Filter, Count, Inspector, Each, etc.)
+4. Schema-modifying nodes transform the schema:
+   - **Join**: merges left + right schemas into a combined struct
+   - **Enrichment nodes** (GeoIp, TextExtractor, EmbeddingGenerator, OpenAiTransformer): append a new field
+   - **Map**: currently pass-through (accurate field tracking is a TODO)
+5. Encoding inherits from the source. If not set, defaults to Avro.
+
+The two-phase approach (inference separate from topology building) allows the UI to report schema errors before any Kafka Streams resources are allocated.
+
+## Build System
+
+### Gradle (Server + Kotlin modules)
+
+Multi-module Gradle project with shared convention plugins:
+
+```
+settings.gradle.kts
+  ├── config/          - Shared configuration classes
+  ├── protos/          - Raw .proto files
+  ├── stub/            - Generated Kotlin/Java gRPC stubs (protobuf-gradle-plugin)
+  ├── libs/testing/    - Test infrastructure (Testcontainers)
+  ├── libs/k8s-client/ - Kubernetes client
+  ├── libs/option/     - Option type
+  ├── server/          - Main server application
+  ├── connectors/demo-data/ - Data generators
+  └── tools/           - Dev utilities
+```
+
+Convention plugins in `buildSrc/` set Kotlin version, JVM target, and common dependencies. Version catalog in `settings.gradle.kts` manages library versions (Kafka 4.1.1, gRPC 1.57.2, Avro 1.11.3, etc.).
+
+Proto code generation: `./gradlew :stub:generateProto` produces Java/Kotlin stubs from `protos/`.
+
+### Go CLI
+
+Built with Go 1.21. `cli/Makefile` handles proto generation and building. Released via GoReleaser to Homebrew tap (`typestreamio/homebrew-tap`).
+
+### UI (Vite + buf)
+
+`uiv2/` uses Vite for dev/build and buf for proto codegen. `buf generate` produces TypeScript message types + Connect-ES client stubs + TanStack Query hooks in `src/generated/`.
+
+### Proto Flow
+
+```
+protos/src/main/proto/*.proto
+    ├── stub/ (Gradle protobuf plugin) → server/ (Kotlin gRPC services)
+    ├── cli/  (protoc via Makefile)    → Go CLI  (Cobra commands)
+    └── uiv2/ (buf)                    → React UI (Connect-ES + TanStack Query)
+```
+
+## Infrastructure
+
+### Docker Compose Services
+
+The full stack (`docker-compose.yml`) includes:
+
+| Service | Image | Port | Purpose |
+|---------|-------|------|---------|
+| `redpanda` | Redpanda v24.2.9 | 19092 (Kafka), 18081 (Schema Registry) | Kafka-compatible broker |
+| `server` | `ghcr.io/typestreamio/server` | 4242 (gRPC) | TypeStream server |
+| `envoy` | Envoy v1.28 | 8080 | gRPC-Web proxy for UI |
+| `kafka-connect` | Custom Debezium image | 8083 | CDC source + JDBC/Weaviate/ES sinks |
+| `postgres` | PostgreSQL 16 | 5432 | Demo database (WAL level=logical for CDC) |
+| `tika` | Apache Tika 2.9.2 | 9998 | Text extraction service |
+| `uiv2` | `ghcr.io/typestreamio/ui` | -- | React frontend (served via Caddy) |
+| `caddy` | Caddy 2 | 80, 443 | Reverse proxy (UI + gRPC) |
+
+**Dev mode** (`docker-compose.dev.yml` overlay): Server runs on the host for hot reload. Envoy routes to `host.docker.internal:4242` instead of the Docker `server` container.
+
+**Demo mode** (`docker-compose.demo.yml`): Adds demo data generators (Coinbase, Wikipedia, web visits).
+
+### External Services
+
+- **GeoIP**: MaxMind GeoLite2 database (bundled in server image)
+- **OpenAI**: REST API for embedding generation and LLM transformations
+
+## CI/CD
+
+GitHub Actions workflows:
+
+| Workflow | Trigger | Purpose |
+|----------|---------|---------|
+| `server-check.yml` | PR / push | Gradle build + test (server, libs, connectors) |
+| `frontend-check.yml` | PR / push | Vite build + lint (uiv2) |
+| `cli-lint.yml` | PR / push | Go lint (cli) |
+| `connectors-check.yml` | PR / push | Connector build check |
+| `docs-check.yml` | PR / push | Documentation site build |
+| `publish-images.yml` | Release / tag | Build and push Docker images to GHCR |
+| `pr-lint.yml` | PR | PR title and label checks |
+| `claude-code-review.yml` | PR | AI-assisted code review |
+| `renovate.yml` | Schedule | Dependency updates |
+
+## Component Docs
+
+- [server/ARCHITECTURE.md](server/ARCHITECTURE.md) -- Kotlin server internals (compiler, scheduler, gRPC services, Kafka Streams topology building, pipeline persistence)
+- [uiv2/ARCHITECTURE.md](uiv2/ARCHITECTURE.md) -- React UI (graph builder, node type mapping, job dashboard, schema validation)
+- [cli/ARCHITECTURE.md](cli/ARCHITECTURE.md) -- Go CLI (local dev orchestration, pipeline-as-code commands, interactive shell, proto generation)
+- [protos/ARCHITECTURE.md](protos/ARCHITECTURE.md) -- Protocol Buffer API contracts (6 services, PipelineGraph data model, code generation targets)
+- [connectors/demo-data/ARCHITECTURE.md](connectors/demo-data/ARCHITECTURE.md) -- Demo data generators (Coinbase, Wikipedia, web visits, file uploads)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,15 +6,19 @@
 
 You draw pipelines visually, TypeStream handles the plumbing. Under the hood it uses Debezium (CDC), Kafka (events), Kafka Streams (transforms), and Kafka Connect (sinks). Your pipeline is also your API -- it computes results and serves them through auto-generated endpoints. No separate database, cache, or API server to maintain.
 
-# Architecture Deep Dives
+# Architecture
 
-For detailed architecture documentation, see:
+See **[ARCHITECTURE.md](ARCHITECTURE.md)** for the system-wide architecture, pipeline lifecycle, node reference, and data flow diagrams.
 
-- **[server/ARCHITECTURE.md](server/ARCHITECTURE.md)** - Kotlin Server architecture including the node graph builder, job system, and compilation pipeline
-- **[uiv2/ARCHITECTURE.md](uiv2/ARCHITECTURE.md)** - React UI architecture with visual graph builder and job management
-- **[connectors/demo-data/ARCHITECTURE.md](connectors/demo-data/ARCHITECTURE.md)** - Demo data generators for Coinbase, Wikipedia, and synthetic web visits
-- cli/ - A Go program to start and stop docker compose containers etc
-- **[website/docs/video-encoding.md](website/docs/video-encoding.md)** - How to record, encode, and embed demo videos on the landing page
+Component-level docs:
+- [server/ARCHITECTURE.md](server/ARCHITECTURE.md) - Kotlin server internals (compiler, scheduler, gRPC services)
+- [uiv2/ARCHITECTURE.md](uiv2/ARCHITECTURE.md) - React UI (graph builder, job dashboard)
+- [cli/ARCHITECTURE.md](cli/ARCHITECTURE.md) - Go CLI (local dev, pipeline-as-code)
+- [protos/ARCHITECTURE.md](protos/ARCHITECTURE.md) - Protocol Buffer API contracts
+- [connectors/demo-data/ARCHITECTURE.md](connectors/demo-data/ARCHITECTURE.md) - Demo data generators
+
+Other docs:
+- [website/docs/video-encoding.md](website/docs/video-encoding.md) - How to record, encode, and embed demo videos on the landing page
 
 # Developing
 

--- a/cli/ARCHITECTURE.md
+++ b/cli/ARCHITECTURE.md
@@ -1,0 +1,253 @@
+> Part of [TypeStream Architecture](../ARCHITECTURE.md)
+
+# CLI Architecture
+
+## Overview
+
+The TypeStream CLI (`typestream`) is a Go binary that serves three roles:
+
+1. **Local development environment** - Orchestrates Docker Compose to run infrastructure services (Redpanda, Envoy, Kafka Connect, UI) and the TypeStream server
+2. **Pipeline-as-code client** - Applies, validates, plans, lists, and deletes pipeline definitions (`.typestream.json` files) via gRPC
+3. **Interactive shell** - REPL that connects to the server over gRPC for running TypeStream DSL commands with syntax highlighting and tab completion
+
+When invoked with no subcommand, the CLI starts the interactive shell. When piped input via stdin, it executes the input as a one-shot program.
+
+## Tech Stack
+
+- **Go 1.21** - compiled binary, cross-platform (linux/darwin/windows)
+- **Cobra** - command tree and flag parsing
+- **gRPC + protobuf** - all server communication (insecure transport, default `127.0.0.1:4242`)
+- **Docker Compose** - local infrastructure orchestration via `docker-compose` CLI
+- **Docker SDK** (`github.com/docker/docker`) - direct container management for seeding
+- **readline** (`github.com/reeflective/readline`) - interactive shell with history, completion
+- **chroma** (`github.com/alecthomas/chroma`) - syntax highlighting in the REPL
+- **charmbracelet/log** - structured logging
+- **GoReleaser** - builds and publishes to Homebrew tap (`typestreamio/homebrew-tap`)
+
+## Directory Structure
+
+```
+cli/
+  main.go                    # Entry point: stdin pipe detection -> shell.Exec or cmd.Execute
+  cmd/
+    root.go                  # Root command, wires subcommands, default action = shell
+    apply.go                 # typestream apply [file]
+    plan.go                  # typestream plan [file|dir]
+    validate.go              # typestream validate [file]
+    pipelines.go             # typestream pipelines list|delete
+    run.go                   # typestream run [file|expr]
+    mount.go                 # typestream mount [config]
+    unmount.go               # typestream unmount [endpoint]
+    local/
+      local.go               # typestream local (parent)
+      dev.go                 # typestream local dev [start|stop|clean]
+      start.go               # typestream local start
+      stop.go                # typestream local stop
+      seed.go                # typestream local seed
+      show.go                # typestream local show
+    k8s/
+      k8s.go                 # typestream k8s (parent)
+      create.go              # typestream k8s create [--redpanda]
+      seed.go                # typestream k8s seed
+  pkg/
+    grpc/
+      client.go              # Shared gRPC client wrapper
+    compose/
+      runner.go              # Docker Compose runner (full stack)
+      dev_runner.go          # Docker Compose runner (dev mode, dependencies only)
+      docker-compose.yml     # (found at project root, located by walking up from cwd)
+      envoy.yaml             # Envoy proxy config (production: server in Docker)
+      envoy-dev.yaml         # Envoy proxy config (dev: server on host)
+      Dockerfile.kafka-connect  # Custom Debezium + Avro converter + Weaviate sink
+      register-connector.sh  # Auto-registers Postgres CDC connector on startup
+      custom-entrypoint.sh   # Runs registration script in background
+      postgres-init.sql      # Demo schema (users, orders, file_uploads)
+      .env.example           # Environment variable template
+    shell/
+      shell.go               # Interactive REPL and one-shot execution
+      prompt.go              # Prompt rendering (shows PWD from server env)
+    k8s/
+      runner.go              # kubectl apply with Go templates
+      typestream.yaml.tmpl   # K8s manifests (Namespace, RBAC, Deployment, Service, ConfigMap)
+      redpanda.yaml          # Redpanda StatefulSet for K8s
+      seeder.yaml.tmpl       # Seeder Job manifest
+    version/
+      version.go             # Build version, Docker image tag logic
+    filesystem_service/      # Generated protobuf + gRPC stubs
+    interactive_session_service/  # Generated protobuf + gRPC stubs
+    job_service/             # Generated protobuf + gRPC stubs
+    pipeline_service/        # Generated protobuf + gRPC stubs
+  Makefile                   # build + proto targets
+  .goreleaser.yaml           # Cross-platform release config
+```
+
+## Command Tree
+
+```
+typestream                          # (no args) Start interactive shell
+  |-- local                         # Manage local Docker environment
+  |     |-- start                   # Start full stack (server + infra) via Docker Compose
+  |     |-- stop                    # Stop full stack
+  |     |-- dev                     # Start infra only (server runs on host for hot reload)
+  |     |     |-- stop              # Stop dev infra
+  |     |     |-- clean             # Stop + remove volumes + purge built images
+  |     |-- seed                    # Pull and run seeder container
+  |     |-- show                    # Print docker-compose.yml contents
+  |-- k8s                           # Manage Kubernetes deployment
+  |     |-- create [--redpanda]     # kubectl apply server manifests (+ optional Redpanda)
+  |     |-- seed                    # kubectl apply seeder Job
+  |-- run [file|expr]               # Create a streaming job from DSL source
+  |-- apply [file]                  # Apply a .typestream.json pipeline definition
+  |-- plan [file|dir]               # Dry-run: show what apply would change
+  |-- validate [file]               # Validate a .typestream.json file without applying
+  |-- pipelines                     # Pipeline management
+  |     |-- list                    # List all managed pipelines (tabular output)
+  |     |-- delete [name]           # Delete a managed pipeline
+  |-- mount [config]                # Mount a data source endpoint
+  |-- unmount [endpoint]            # Unmount a data source endpoint
+```
+
+## gRPC Client
+
+All server communication goes through `pkg/grpc/client.go`, which wraps a single `grpc.ClientConn`.
+
+**Connection**: Dials `TYPESTREAM_HOST:TYPESTREAM_PORT` (defaults: `127.0.0.1:4242`) with insecure credentials. Each command creates a `Client`, uses it within a context with timeout, and defers `Close()`.
+
+**Service clients**: The `Client` struct instantiates per-call service clients from the shared connection:
+
+| Method | gRPC Service | Used By |
+|--------|-------------|---------|
+| `StartSession`, `RunProgram`, `GetProgramOutput`, `CompleteProgram`, `StopSession` | `InteractiveSessionService` | Shell |
+| `CreateJob` | `JobService` | `run` command |
+| `Mount`, `Unmount` | `FileSystemService` | `mount`/`unmount` commands |
+| `ApplyPipeline`, `ValidatePipeline`, `ListPipelines`, `DeletePipeline`, `PlanPipelines` | `PipelineService` | Pipeline-as-code commands |
+
+## Docker Compose Orchestration
+
+Two runners manage Docker Compose with different profiles:
+
+### `Runner` (full stack, `typestream local start`)
+
+- Project name: `typestream`
+- Compose file: `docker-compose.yml` (located by walking up from cwd)
+- Sets `TYPESTREAM_IMAGE` env var from `version.DockerImage("typestream/server")`
+- Runs the TypeStream server inside Docker alongside all infrastructure
+
+### `DevRunner` (dev mode, `typestream local dev`)
+
+- Project name: `typestream-dev`
+- Compose files: `docker-compose.yml` + `docker-compose.dev.yml` (overlay)
+- Sets `TYPESTREAM_PROJECT_ROOT` env var (project root, 3 directories up from `pkg/compose/`)
+- Server runs on the host machine (not in Docker) for fast Kotlin iteration
+- Envoy dev config routes gRPC to `host.docker.internal:4242` instead of Docker `server:4242`
+
+Both runners capture Docker Compose stderr and forward it through a `StdOut` channel. The command goroutine parses regex patterns to present user-friendly progress messages (building, started, healthy).
+
+**Port conflict detection**: `typestream local start` checks if port 4242 is already bound (e.g., by a Gradle dev server) before attempting to start.
+
+### Infrastructure Services
+
+The Docker Compose stack includes:
+- **Redpanda** - Kafka-compatible broker + Schema Registry
+- **Envoy** - gRPC-Web proxy (routes `/` to TypeStream server, `/connect/` to Kafka Connect)
+- **Kafka Connect** - Custom Debezium image with Avro converters and Weaviate sink connector
+- **PostgreSQL** - Demo database with CDC-enabled tables
+- **Kafbat UI** - Kafka topic browser (port 8088)
+- **TypeStream UI** - React frontend (port 5173, dev mode)
+
+## Pipeline-as-Code Commands
+
+The `apply`, `plan`, and `validate` commands all share `parsePipelineFile()` (defined in `cmd/validate.go`) to parse `.typestream.json` files:
+
+```json
+{
+  "name": "my-pipeline",
+  "version": "1",
+  "description": "optional description",
+  "graph": { /* PipelineGraph protobuf as JSON */ }
+}
+```
+
+**Parsing**: The top-level fields (`name`, `version`, `description`) are extracted with `encoding/json`. The `graph` field is deserialized with `protojson.Unmarshal` into a `job_service.PipelineGraph` proto message. This produces a `PipelineMetadata` + `PipelineGraph` pair sent to the server.
+
+### apply
+
+Sends `ApplyPipelineRequest` and reports whether the pipeline was CREATED, UPDATED, or UNCHANGED.
+
+### plan
+
+Accepts a single file or a directory (scans for `*.typestream.json`). Collects all pipeline definitions into a `PlanPipelinesRequest`, sends to server, and displays a table with color-coded actions (green = create, yellow = update, dim = unchanged, red = delete).
+
+### validate
+
+Sends `ValidatePipelineRequest` and prints validation errors if any.
+
+### pipelines list / delete
+
+`list` shows a table of all managed pipelines (name, version, job ID, state, description). `delete` removes a pipeline by name.
+
+## Proto Generation
+
+Run `make proto` from the `cli/` directory to regenerate Go stubs from `../protos/src/main/proto/*.proto`.
+
+**Version constraints**: The generated stubs must use `protoc-gen-go v1.31.0` and `protoc-gen-go-grpc v1.2.0`. Newer versions (e.g., v1.6.1) generate `grpc.SupportPackageIsVersion9` which is incompatible with the `google.golang.org/grpc v1.59.0` dependency.
+
+Each proto service is generated into its own `pkg/<service>/` directory. The `pipeline.proto` imports `job.proto` (for `PipelineGraph`), so they must be generated separately to avoid duplicating job types.
+
+```makefile
+proto:
+  protoc --go_out=pkg/interactive_session_service ... interactive_session.proto
+  protoc --go_out=pkg/job_service ... job.proto
+  protoc --go_out=pkg/filesystem_service ... filesystem.proto
+  protoc --go_out=pkg/pipeline_service ... pipeline.proto
+```
+
+## Interactive Shell
+
+When `typestream` is invoked with no subcommand, `shell.Run()` starts an interactive REPL:
+
+1. Opens a gRPC session via `InteractiveSessionService.StartSession`
+2. Creates a readline shell with syntax highlighting (chroma, bash lexer) and tab completion (server-side via `CompleteProgram`)
+3. Each input line is sent via `RunProgram`; if the response has `HasMoreOutput`, streams results via `GetProgramOutput` (server-sent stream)
+4. Ctrl+C sends a `kill <id>` command to cancel a running program
+5. On exit, calls `StopSession` to clean up server-side resources
+6. History is persisted to `~/.typestream_history`
+
+When stdin is piped (`echo "ls /dev" | typestream`), `main.go` detects the pipe and calls `shell.Exec()` for one-shot execution instead of the REPL.
+
+## Integration Points
+
+```
+                     ┌──────────────┐
+                     │   Envoy      │ :8080
+                     │  (gRPC-Web)  │
+                     └──────┬───────┘
+                            │
+   ┌────────────────────────┼──────────────────────┐
+   │                        │                      │
+   │  CLI (typestream)      │   React UI           │
+   │  gRPC :4242 ───────────┤   Connect :8080 ─────┤
+   │                        │                      │
+   └────────────────────────┼──────────────────────┘
+                            │
+                     ┌──────┴───────┐
+                     │  TypeStream  │ :4242
+                     │   Server     │
+                     └──────────────┘
+```
+
+- **CLI to Server**: Direct gRPC on port 4242 (no proxy needed)
+- **UI to Server**: gRPC-Web through Envoy proxy on port 8080
+- **CLI to Docker**: Docker Compose CLI for infrastructure lifecycle, Docker SDK for seeding
+- **CLI to Kubernetes**: kubectl CLI for K8s deployments
+
+## Release
+
+GoReleaser builds cross-platform binaries and publishes to `typestreamio/homebrew-tap`. Version and commit hash are injected via ldflags:
+
+```
+-X github.com/typestreamio/typestream/cli/pkg/version.Version={{.Version}}
+-X github.com/typestreamio/typestream/cli/pkg/version.CommitHash={{.Commit}}
+```
+
+Docker image tags are derived from the build version, with `+` replaced by `.` for Docker tag compatibility. Beta builds use GHCR (`ghcr.io/typestreamio/`).

--- a/protos/ARCHITECTURE.md
+++ b/protos/ARCHITECTURE.md
@@ -1,0 +1,257 @@
+> Part of [TypeStream Architecture](../ARCHITECTURE.md)
+
+# Protocol Buffers -- API Contracts
+
+The `protos/` module defines the gRPC service contracts and data models that form the API surface of the TypeStream platform. These proto definitions are the single source of truth consumed by three codegen targets: Kotlin (server), Go (CLI), and TypeScript (UI).
+
+## Proto File Catalog
+
+| File | Package | Services | Key Messages |
+|------|---------|----------|--------------|
+| `connection.proto` | `io.typestream.grpc` | `ConnectionService` | `DatabaseConnectionConfig`, `WeaviateConnectionConfig`, `ElasticsearchConnectionConfig`, `ConnectionStatus` |
+| `filesystem.proto` | `io.typestream.grpc` | `FileSystemService` | `FileInfo`, `LsResponse`, `GetSchemaResponse` |
+| `interactive_session.proto` | `io.typestream.grpc` | `InteractiveSessionService` | `RunProgramResponse`, `GetProgramOutputResponse`, `CompleteProgramResponse` |
+| `job.proto` | `io.typestream.grpc` | `JobService` | `PipelineGraph`, `PipelineNode`, `JobInfo`, `CreatePreviewJobRequest`, `NodeSchemaResult` |
+| `pipeline.proto` | `io.typestream.grpc` | `PipelineService` | `PipelineMetadata`, `PipelineInfo`, `PipelinePlanResult` |
+| `state_query.proto` | `io.typestream.grpc` | `StateQueryService` | `StoreInfo`, `KeyValuePair`, `GetValueResponse` |
+
+All files use `syntax = "proto3"` and share the `io.typestream.grpc` package. Each file sets language-specific package options (`java_package`, `go_package`).
+
+## Service Reference
+
+### ConnectionService (`connection.proto`)
+
+Manages external data store connections (databases, Weaviate, Elasticsearch) and creates Kafka Connect sink connectors.
+
+| RPC | Request | Response | Description |
+|-----|---------|----------|-------------|
+| `RegisterConnection` | `RegisterConnectionRequest` | `RegisterConnectionResponse` | Register a database connection for health monitoring |
+| `UnregisterConnection` | `UnregisterConnectionRequest` | `UnregisterConnectionResponse` | Stop monitoring a connection |
+| `GetConnectionStatuses` | `GetConnectionStatusesRequest` | `GetConnectionStatusesResponse` | Get status of all monitored database connections |
+| `TestConnection` | `TestConnectionRequest` | `TestConnectionResponse` | One-shot connection test (no registration) |
+| `CreateJdbcSinkConnector` | `CreateJdbcSinkConnectorRequest` | `CreateJdbcSinkConnectorResponse` | Create a JDBC sink connector (credentials resolved server-side) |
+| `RegisterWeaviateConnection` | `RegisterWeaviateConnectionRequest` | `RegisterWeaviateConnectionResponse` | Register a Weaviate connection |
+| `GetWeaviateConnectionStatuses` | `GetWeaviateConnectionStatusesRequest` | `GetWeaviateConnectionStatusesResponse` | Get status of all Weaviate connections |
+| `CreateWeaviateSinkConnector` | `CreateWeaviateSinkConnectorRequest` | `CreateWeaviateSinkConnectorResponse` | Create a Weaviate sink connector |
+| `RegisterElasticsearchConnection` | `RegisterElasticsearchConnectionRequest` | `RegisterElasticsearchConnectionResponse` | Register an Elasticsearch connection |
+| `GetElasticsearchConnectionStatuses` | `GetElasticsearchConnectionStatusesRequest` | `GetElasticsearchConnectionStatusesResponse` | Get status of all Elasticsearch connections |
+| `CreateElasticsearchSinkConnector` | `CreateElasticsearchSinkConnectorRequest` | `CreateElasticsearchSinkConnectorResponse` | Create an Elasticsearch sink connector |
+
+Security note: Connection configs include credentials (`DatabaseConnectionConfig.password`, `WeaviateConnectionConfig.api_key`, `ElasticsearchConnectionConfig.password`), but public-facing status messages use credential-stripped variants (`DatabaseConnectionConfigPublic`, `WeaviateConnectionConfigPublic`, `ElasticsearchConnectionConfigPublic`).
+
+### FileSystemService (`filesystem.proto`)
+
+Virtual filesystem that exposes Kafka topics as paths.
+
+| RPC | Request | Response | Description |
+|-----|---------|----------|-------------|
+| `Mount` | `MountRequest` | `MountResponse` | Mount a data source endpoint |
+| `Unmount` | `UnmountRequest` | `UnmountResponse` | Unmount an endpoint |
+| `Ls` | `LsRequest` | `LsResponse` | List files/topics at a path |
+| `GetSchema` | `GetSchemaRequest` | `GetSchemaResponse` | Get field names for a topic |
+
+### InteractiveSessionService (`interactive_session.proto`)
+
+REPL-style interactive shell for running TypeStream DSL programs.
+
+| RPC | Request | Response | Description |
+|-----|---------|----------|-------------|
+| `StartSession` | `StartSessionRequest` | `StartSessionResponse` | Create a new interactive session |
+| `RunProgram` | `RunProgramRequest` | `RunProgramResponse` | Execute DSL source in a session |
+| `GetProgramOutput` | `GetProgramOutputRequest` | `stream GetProgramOutputResponse` | Stream ongoing output from a running program |
+| `CompleteProgram` | `CompleteProgramRequest` | `CompleteProgramResponse` | Tab-completion for DSL source |
+| `StopSession` | `StopSessionRequest` | `StopSessionResponse` | Terminate a session |
+
+### JobService (`job.proto`)
+
+Core service for creating and managing Kafka Streams jobs.
+
+| RPC | Request | Response | Description |
+|-----|---------|----------|-------------|
+| `CreateJob` | `CreateJobRequest` | `CreateJobResponse` | Create a job from DSL source code |
+| `CreateJobFromGraph` | `CreateJobFromGraphRequest` | `CreateJobResponse` | Create a job from a `PipelineGraph` (used by the UI) |
+| `ListJobs` | `ListJobsRequest` | `ListJobsResponse` | List all jobs with state and throughput metrics |
+| `CreatePreviewJob` | `CreatePreviewJobRequest` | `CreatePreviewJobResponse` | Start a temporary preview job for data inspection |
+| `StopPreviewJob` | `StopPreviewJobRequest` | `StopPreviewJobResponse` | Stop a preview job |
+| `StreamPreview` | `StreamPreviewRequest` | `stream StreamPreviewResponse` | Stream key-value records from a preview job |
+| `InferGraphSchemas` | `InferGraphSchemasRequest` | `InferGraphSchemasResponse` | Infer output schemas for all nodes in a graph |
+| `ListOpenAIModels` | `ListOpenAIModelsRequest` | `ListOpenAIModelsResponse` | List available OpenAI models for AI nodes |
+
+### PipelineService (`pipeline.proto`)
+
+Pipeline-as-code management: validate, apply, plan, and delete named pipelines.
+
+| RPC | Request | Response | Description |
+|-----|---------|----------|-------------|
+| `ValidatePipeline` | `ValidatePipelineRequest` | `ValidatePipelineResponse` | Validate a pipeline definition without applying |
+| `ApplyPipeline` | `ApplyPipelineRequest` | `ApplyPipelineResponse` | Create or update a named pipeline |
+| `ListPipelines` | `ListPipelinesRequest` | `ListPipelinesResponse` | List all applied pipelines with job state |
+| `DeletePipeline` | `DeletePipelineRequest` | `DeletePipelineResponse` | Delete a named pipeline |
+| `PlanPipelines` | `PlanPipelinesRequest` | `PlanPipelinesResponse` | Dry-run: show what would change (CREATE/UPDATE/DELETE/NO_CHANGE) |
+
+### StateQueryService (`state_query.proto`)
+
+Interactive queries against KTable state stores from running Kafka Streams jobs.
+
+| RPC | Request | Response | Description |
+|-----|---------|----------|-------------|
+| `ListStores` | `ListStoresRequest` | `ListStoresResponse` | List queryable state stores from running jobs |
+| `GetAllValues` | `GetAllValuesRequest` | `stream KeyValuePair` | Stream all key-value pairs from a store (with limit) |
+| `GetValue` | `GetValueRequest` | `GetValueResponse` | Look up a single value by string key |
+
+Limitation: `GetValue` only supports simple string keys. For complex keys (structs), use `GetAllValues` and filter client-side.
+
+## PipelineGraph Data Model
+
+`PipelineGraph` is the canonical intermediate representation for visual pipelines. It is a directed acyclic graph of typed nodes connected by edges.
+
+```protobuf
+message PipelineGraph {
+  repeated PipelineNode nodes = 1;
+  repeated PipelineEdge edges = 2;
+}
+
+message PipelineEdge {
+  string from_id = 1;
+  string to_id = 2;
+}
+```
+
+### PipelineNode
+
+Each node has a unique `id` and exactly one `node_type` via a `oneof` discriminator. There are **17 node types**:
+
+#### Source Nodes
+| Node | Fields | Description |
+|------|--------|-------------|
+| `StreamSourceNode` | `data_stream`, `encoding`, `unwrap_cdc` | Reads from a Kafka topic. `unwrap_cdc` extracts the `after` payload from CDC envelopes. |
+| `ShellSourceNode` | `data` (repeated) | Source for interactive shell commands, referencing multiple data streams. |
+
+#### Transform Nodes
+| Node | Fields | Description |
+|------|--------|-------------|
+| `FilterNode` | `by_key`, `predicate` | Filters records. `predicate.expr` holds the filter expression; `by_key` applies it to keys. |
+| `MapNode` | `mapper_expr` | Transforms record values using a mapping expression. |
+| `EachNode` | `fn_expr` | Applies a side-effect function to each record. |
+| `GroupNode` | `key_mapper_expr` | Re-keys records for downstream aggregation. |
+| `JoinNode` | `with`, `join_type` | Joins with another stream. `join_type` controls `by_key` and `is_lookup` semantics. |
+| `NoOpNode` | _(none)_ | Pass-through, used as a structural placeholder. |
+
+#### Aggregation Nodes
+| Node | Fields | Description |
+|------|--------|-------------|
+| `CountNode` | _(none)_ | Counts records into a KTable. |
+| `WindowedCountNode` | `window_size_seconds` | Time-windowed count (e.g., 60 for 1-minute tumbling windows). |
+| `ReduceLatestNode` | _(none)_ | Keeps only the latest value per key. |
+
+#### AI / Enrichment Nodes
+| Node | Fields | Description |
+|------|--------|-------------|
+| `GeoIpNode` | `ip_field`, `output_field` | Enriches records with geolocation data from an IP address field. |
+| `TextExtractorNode` | `file_path_field`, `output_field` | Extracts text content from a file path field. |
+| `EmbeddingGeneratorNode` | `text_field`, `output_field`, `model` | Generates vector embeddings via OpenAI. |
+| `OpenAiTransformerNode` | `prompt`, `output_field`, `model` | Transforms records using an OpenAI LLM with a user prompt. |
+
+#### Sink / Inspection Nodes
+| Node | Fields | Description |
+|------|--------|-------------|
+| `SinkNode` | `output`, `encoding` | Writes records to an output Kafka topic. |
+| `InspectorNode` | `label` | Taps the stream for preview/debugging without altering data flow. |
+
+### Sink Connector Configs
+
+`CreateJobFromGraphRequest` carries optional sink connector configurations alongside the graph:
+
+- **`DbSinkConfig`** -- JDBC sink: `connection_id`, `table_name`, `insert_mode`, `primary_key_fields`, `intermediate_topic`
+- **`WeaviateSinkConfig`** -- Weaviate vector DB sink: `collection_name`, `document_id_strategy`, `vector_strategy`, `timestamp_field`
+- **`ElasticsearchSinkConfig`** -- Elasticsearch sink: `index_name`, `document_id_strategy`, `write_method`, `behavior_on_null_values`
+
+All sink configs use `connection_id` for server-side credential resolution -- credentials never leave the server.
+
+### Supporting Types
+
+- **`Encoding`** enum: `STRING`, `NUMBER`, `JSON`, `AVRO`, `PROTOBUF`
+- **`JobState`** enum: `STARTING`, `RUNNING`, `STOPPING`, `STOPPED`, `FAILED`, `UNKNOWN`
+- **`PipelineState`** enum: `CREATED`, `UPDATED`, `UNCHANGED`
+- **`PipelineAction`** enum: `CREATE`, `UPDATE`, `NO_CHANGE`, `DELETE`
+- **`ConnectionState`** enum: `CONNECTED`, `DISCONNECTED`, `ERROR`, `CONNECTING`
+- **`DatabaseType`** enum: `POSTGRES`, `MYSQL`
+
+## Code Generation
+
+### Kotlin (Server)
+
+The `stub/` module uses the [protobuf-gradle-plugin](https://github.com/google/protobuf-gradle-plugin) v0.9.4:
+
+```
+stub/build.gradle.kts
+  protobuf(project(":protos"))     <- imports proto sources
+  protoc-gen-grpc-java             <- Java gRPC stubs
+  protoc-gen-grpc-kotlin           <- Kotlin coroutine stubs
+  builtin kotlin                   <- Kotlin DSL builders
+```
+
+Generated code lands in `stub/build/generated/source/proto/main/{java,grpc,kotlin,grpckt}`. Build with:
+
+```bash
+./gradlew :stub:generateProto
+```
+
+### Go (CLI)
+
+The `cli/Makefile` runs `protoc` directly for each service:
+
+```bash
+cd cli && make proto
+```
+
+Each service generates into its own package under `cli/pkg/<service>/`:
+- `interactive_session_service/`
+- `job_service/`
+- `filesystem_service/`
+- `pipeline_service/`
+
+Version constraints: `protoc-gen-go v1.31.0` and `protoc-gen-go-grpc v1.2.0`. Newer versions produce `SupportPackageIsVersion9` which is incompatible with the project's `grpc v1.59.0`.
+
+Note: `pipeline.proto` imports `job.proto` (for `PipelineGraph`, `JobState`). The Makefile generates them separately to avoid duplicate type definitions.
+
+### TypeScript (UI)
+
+The `uiv2/` directory uses [buf](https://buf.build/) with `buf.yaml` pointing at `../protos/src/main/proto`:
+
+```yaml
+# buf.gen.yaml
+plugins:
+  - protoc-gen-es          -> TypeScript message types
+  - protoc-gen-connect-es  -> Connect-ES client stubs
+  - protoc-gen-connect-query -> TanStack Query integration
+```
+
+Generated code goes to `uiv2/src/generated/`. The UI uses `@bufbuild/protobuf` for `toJson()`/`fromJson()` serialization.
+
+## Package Naming
+
+All proto files use `package io.typestream.grpc` with per-language overrides:
+
+| Language | Package Pattern | Example |
+|----------|----------------|---------|
+| Java/Kotlin | `io.typestream.grpc.<service>_service` | `io.typestream.grpc.job_service` |
+| Go | `github.com/typestreamio/typestream/cli/pkg/<service>_service` | `.../pkg/job_service` |
+| TypeScript | Generated by buf into `src/generated/` | flat output directory |
+
+## Integration Points
+
+```
+protos/src/main/proto/*.proto
+        |
+        +---> stub/ (Gradle)  ---> server/  (Kotlin gRPC services)
+        |
+        +---> cli/  (protoc)  ---> Go CLI   (Cobra commands calling gRPC)
+        |
+        +---> uiv2/ (buf)     ---> React UI (Connect-ES + TanStack Query)
+```
+
+- **Server** implements all six gRPC services, using the generated Kotlin coroutine stubs from `stub/`.
+- **CLI** calls `InteractiveSessionService`, `JobService`, `FileSystemService`, and `PipelineService` through Go gRPC stubs.
+- **UI** calls `JobService`, `ConnectionService`, `FileSystemService`, `PipelineService`, and `StateQueryService` through Connect-ES (gRPC-Web).
+- **`PipelineGraph`** is the shared data model: the UI builds it visually, sends it via `CreateJobFromGraph` or `ApplyPipeline`, and the server compiles it to a Kafka Streams topology.

--- a/server/ARCHITECTURE.md
+++ b/server/ARCHITECTURE.md
@@ -1,8 +1,11 @@
 # TypeStream Server Architecture
 
+> Part of [TypeStream Architecture](../ARCHITECTURE.md)
+> See [Node Reference](../ARCHITECTURE.md#node-reference) and [Pipeline Lifecycle](../ARCHITECTURE.md#pipeline-lifecycle) for system-wide concepts.
+
 ## Overview
 
-The server is the core of TypeStream - a Kotlin-based streaming data platform that compiles pipe-based commands into Kafka Streams topologies. It provides a UNIX-like abstraction over Kafka topics (`/dev/kafka/...`) and executes streaming jobs.
+The server is the core of TypeStream -- a Kotlin-based streaming data platform that compiles pipe-based commands into Kafka Streams topologies. It provides a UNIX-like abstraction over Kafka topics (`/dev/kafka/...`) and executes streaming jobs.
 
 ## Tech Stack
 
@@ -25,87 +28,92 @@ server/src/main/kotlin/io/typestream/
 │   ├── GraphCompiler.kt             # Proto → Graph
 │   ├── Interpreter.kt               # AST type binding
 │   ├── Infer.kt                     # Type validation
+│   ├── PipelineGraphEmitter.kt      # DSL → PipelineGraph proto
 │   ├── ast/                         # AST node definitions
 │   ├── lexer/                       # Tokenization
 │   ├── parser/                      # Parsing
 │   ├── node/                        # Execution graph nodes
 │   ├── types/                       # Type system (DataStream, Schema)
 │   └── vm/                          # Virtual machine
+├── pipeline/                        # Pipeline-as-Code
+│   ├── PipelineFileParser.kt        # YAML pipeline file parsing
+│   └── PipelineStateStore.kt        # Kafka-backed persistent state
 ├── scheduler/                       # Job lifecycle
 │   ├── Scheduler.kt                 # Job orchestration
 │   ├── KafkaStreamsJob.kt           # Embedded execution
 │   └── K8sJob.kt                    # Kubernetes execution
 ├── filesystem/                      # Virtual filesystem
 ├── server/                          # gRPC service implementations
-└── kafka/                           # Kafka utilities & serdes
+│   ├── PipelineService.kt          # Pipeline CRUD + plan/diff
+│   ├── JobService.kt               # Job management
+│   ├── ConnectionService.kt        # Database connections + JDBC sink
+│   ├── FileSystemService.kt        # Virtual filesystem operations
+│   ├── InteractiveSessionService.kt # Interactive REPL
+│   └── StateQueryService.kt        # State store queries
+├── kafka/                           # Kafka utilities & serdes
+├── geoip/                           # GeoIP enrichment service
+├── textextractor/                   # Text extraction service
+├── embedding/                       # Embedding generation service
+└── openai/                          # OpenAI transformer service
 ```
 
-## Node Graph Builder
+## Compilation Pipeline
 
-The node graph builder transforms user programs into typed execution graphs through multiple phases:
-
-### Compilation Flow
-
-```
-Source Code (e.g., "cat /dev/kafka/.../topic | grep x")
-    ↓
-[Lexer] → Tokens
-    ↓
-[Parser] → AST (Pipeline, DataCommand, Expr)
-    ↓
-[Interpreter] → Resolved AST (bind data streams, infer encoding)
-    ↓
-[Compiler] → Graph<Node>
-    ↓
-[Infer] → Validated Graph with type info
-    ↓
-[Program] (graph + metadata)
-```
+The server transforms user programs into typed execution graphs. For the full list of node types and their behaviors, see the [Node Reference](../ARCHITECTURE.md#node-reference) in the root architecture doc.
 
 ### Two Compilation Paths
 
-1. **Text-based** (`Compiler.kt`): Parses TypeStream DSL commands
-2. **Proto-based** (`GraphCompiler.kt`): Accepts UI-built pipeline graphs
+1. **Text-based** (`Compiler.kt`): Parses TypeStream DSL commands through Lexer -> Parser -> Interpreter -> Graph<Node>
+2. **Proto-based** (`GraphCompiler.kt`): Accepts UI-built `PipelineGraph` protos and compiles them to `Graph<Node>`
 
-### Node Types
+Both paths converge at `Graph<Node>`, which is then passed to `Infer` for type validation and wrapped in a `Program`.
 
-The graph is composed of sealed interface `Node` types:
+```
+Text Path:  Source Code → [Lexer] → [Parser] → [Interpreter] → Graph<Node>
+Proto Path: PipelineGraph proto → [GraphCompiler] → Graph<Node>
+                                                        ↓
+                                                    [Infer] → Validated Graph
+                                                        ↓
+                                                    Program (graph + metadata)
+```
 
-| Node | Purpose |
-|------|---------|
-| `StreamSource` | Reads from Kafka topic |
-| `Filter` | Filters records by predicate |
-| `Map` | Transforms records |
-| `Join` | Joins two streams |
-| `Group` | Groups by key |
-| `Count` | Counts records |
-| `Sink` | Writes to Kafka topic |
-| `Each` | Side effects |
+### GraphCompiler Internals
 
-### Type System
+`GraphCompiler.compile()` translates each `PipelineNode` proto into its corresponding `Node` sealed class instance:
+
+- Resolves `DataStream` paths against the virtual filesystem to bind schema metadata
+- Auto-detects encoding from Schema Registry when not explicitly set
+- Validates that edges form a valid DAG
+- Calls `inferOutputSchema()` on each node to propagate schemas through the graph
+
+### Schema Inference
 
 Each `Node` type encapsulates its own schema transformation via `inferOutputSchema()`:
 - Schema inference is co-located with node definitions in `Node.kt`
 - Adding a new node type only requires implementing `inferOutputSchema()` in one place
+- The `InferenceContext` interface provides access to the filesystem catalog for external lookups
 - Validates schema compatibility at compile time
 
 ## Jobs
 
 Jobs execute compiled programs as Kafka Streams topologies.
 
-### Job Lifecycle
+### KafkaStreamsJob
 
-```
-Program (compiled graph)
-    ↓
-Job Interface (sealed)
-├── KafkaStreamsJob  (embedded)
-└── K8sJob           (Kubernetes)
-    ↓
-Scheduler (coroutine-based)
-    ↓
-Output Stream (Flow<String>)
-```
+The primary job executor for local/embedded mode:
+
+1. Takes compiled `Program` and `KafkaConfig`
+2. `buildTopology()` walks the `Graph<Node>` and converts each node to Kafka Streams operators:
+   - `StreamSource` → `StreamsBuilder.stream()` with appropriate serde
+   - `Filter` → `.filter()` / `.filterNot()` based on predicate
+   - `Group` → `.groupBy()` with key mapper
+   - `Count` / `WindowedCount` → `.count()` / `.windowedBy().count()`
+   - `Join` → `.join()` / `.leftJoin()` with the secondary stream
+   - `GeoIp`, `TextExtractor`, `EmbeddingGenerator`, `OpenAiTransformer` → `.mapValues()` with enrichment logic
+   - `Sink` → `.to()` target topic
+3. `start()` launches `KafkaStreams` instance
+4. `output()` streams results from the job's `-stdout` topic
+5. `state()` maps `KafkaStreams.State` to `Job.State`
 
 ### Job States
 
@@ -115,31 +123,58 @@ STARTING → RUNNING → STOPPING → STOPPED
            FAILED
 ```
 
-### KafkaStreamsJob
-
-The primary job executor for local/embedded mode:
-
-1. Takes compiled `Program` and `KafkaConfig`
-2. `buildTopology()` converts `Graph<Node>` to Kafka Streams topology
-3. `start()` launches KafkaStreams instance
-4. `output()` streams results from `-stdout` topic
-5. `state()` maps KafkaStreams state to Job.State
-
 ### Scheduler
 
 Manages job lifecycle with Kotlin coroutines:
-- Channel-based job queue
-- Thread-safe job collection
-- Supports K8s mode for external job monitoring
+- Channel-based job queue with `submit()` / `kill()` / `ps()`
+- Thread-safe job collection via `ConcurrentHashMap`
+- Supports K8s mode for external job monitoring via `K8sJob`
+
+## Pipeline-as-Code
+
+The `PipelineService` provides declarative pipeline management with persistent state.
+
+### PipelineService
+
+Manages the full lifecycle of named pipelines:
+
+| RPC | Purpose |
+|-----|---------|
+| `ValidatePipeline` | Dry-run compile to check for errors |
+| `ApplyPipeline` | Create or update a pipeline (stop old job, start new) |
+| `DeletePipeline` | Stop and remove a pipeline |
+| `ListPipelines` | List all managed pipelines with job state |
+| `PlanPipelines` | Dry-run diff showing CREATE/UPDATE/DELETE/NO_CHANGE actions |
+
+Apply logic:
+1. If a pipeline with the same name exists and the graph is unchanged, returns `UNCHANGED`
+2. If the graph changed, kills the existing job, compiles and starts a new one, returns `UPDATED`
+3. For new pipelines, compiles and starts, returns `CREATED`
+4. Persists the pipeline record to the state store after successful apply
+
+### PipelineStateStore
+
+Persistent pipeline state backed by a Kafka compacted topic:
+
+- **Topic**: `__typestream_pipelines` (compacted, single partition)
+- **Key**: pipeline name (string)
+- **Value**: JSON-serialized `PipelineRecord` containing `PipelineMetadata` + `PipelineGraph` proto + `appliedAt` timestamp
+- **Tombstones**: `null` value for deletions
+
+On server startup, `PipelineStateStore.load()` consumes the entire compacted topic from beginning to end, rebuilding the current state map. Then `PipelineService.recoverPipelines()` recompiles and restarts each pipeline's Kafka Streams job.
 
 ## gRPC Services
 
 | Service | Methods | Purpose |
 |---------|---------|---------|
+| PipelineService | ValidatePipeline, ApplyPipeline, DeletePipeline, ListPipelines, PlanPipelines | Declarative pipeline management |
+| JobService | CreateJob, CreateJobFromGraph, ListJobs, InferGraphSchemas | Job management and schema inference |
 | FileSystemService | Mount, Unmount, Ls | Virtual filesystem operations |
 | InteractiveSessionService | StartSession, RunProgram, GetProgramOutput | Interactive REPL |
-| JobService | CreateJob, CreateJobFromGraph, ListJobs | Job management |
-| ConnectionService | RegisterConnection, GetConnectionStatuses, TestConnection | Database connection monitoring |
+| ConnectionService | RegisterConnection, GetConnectionStatuses, TestConnection, CreateJdbcSinkConnector | Database connection monitoring + sink connector management |
+| StateQueryService | GetValue, GetAllValues, ListStores | Interactive queries on running Kafka Streams state stores |
+
+All services are registered in `Server.kt` with `ExceptionInterceptor` and `LoggerInterceptor`. Proto reflection is enabled for tools like `grpcurl`.
 
 ## Virtual Filesystem
 
@@ -149,45 +184,15 @@ Kafka topics are exposed as a UNIX-like filesystem:
 /dev/kafka/{cluster}/topics/{topic}
 ```
 
-- **FileSystem.kt**: Root filesystem abstraction
-- **Catalog**: Metadata cache (schemas from Schema Registry)
+- **FileSystem.kt**: Root filesystem abstraction, watches for metadata changes
+- **Catalog**: Metadata cache backed by Schema Registry lookups
 - Enables commands like `cat`, `ls`, `grep` on topics
 
 ## Avro Serialization
 
 TypeStream uses Avro as its primary serialization format. The `kafka/` package handles serialization/deserialization with Schema Registry integration.
 
-### Deserialization Flow
-
-```
-Kafka Message: [magic byte (0x00)] [schema ID (4 bytes)] [avro binary data]
-                                          │
-                                          ▼
-                            Schema Registry (cached lookup)
-                                          │
-                                          ▼
-                            AvroSerde.deserialize()
-                            ├── Reads schema ID from message
-                            ├── Fetches writer schema from registry
-                            └── Deserializes using writer schema
-                                          │
-                                          ▼
-                                    GenericRecord
-```
-
-### Key Design Decision
-
-The deserializer fetches the **writer's schema** from Schema Registry using the schema ID embedded in each message. This enables TypeStream to read topics produced by external systems (like Debezium CDC) that use different schema namespaces.
-
-### External Producer Support
-
-TypeStream can consume Avro topics from any producer:
-
-| Producer | Schema Example | Works? |
-|----------|----------------|--------|
-| TypeStream demo-data | `namespace: io.typestream.connectors.avro` | ✓ |
-| Debezium CDC | `namespace: dbserver.public.users, name: Envelope` | ✓ |
-| Confluent producers | Any valid Avro schema | ✓ |
+The deserializer fetches the **writer's schema** from Schema Registry using the schema ID embedded in each message (`[0x00][schema ID (4 bytes)][avro binary]`). This enables TypeStream to read topics produced by external systems (like Debezium CDC) that use different schema namespaces.
 
 ### Key Files
 
@@ -201,96 +206,19 @@ TypeStream can consume Avro topics from any producer:
 
 TypeStream supports consuming Change Data Capture (CDC) events from Debezium. The `unwrapCdc` flag on `StreamSource` nodes extracts the "after" payload from CDC envelope structures.
 
-### CDC Envelope Structure
-
-Debezium emits CDC events with this schema:
 ```
-{
-  "before": { ... },    // Previous state (null for inserts)
-  "after": { ... },     // New state (null for deletes)
-  "source": { ... },    // Debezium metadata
-  "op": "c|u|d|r",      // Operation type
-  "ts_ms": 1234567890
-}
-```
-
-### CDC Unwrapping Flow
-
-```
-Debezium Topic (CDC envelope)
+Debezium Topic (CDC envelope: before/after/source/op/ts_ms)
         ↓
 StreamSource(unwrapCdc=true)
         ↓
-[StreamSource.inferOutputSchema() → DataStream.unwrapCdc()]
-  ├── Detects CDC envelope (before/after/source/op fields)
-  ├── Extracts schema from "after" field
-  └── Returns DataStream with unwrapped schema
+DataStream.unwrapCdc() extracts schema from "after" field
         ↓
 Downstream nodes receive flattened records
 ```
 
-### Key Files
-
-| File | Function |
-|------|----------|
-| `DataStream.kt:unwrapCdc()` | Schema extraction from CDC envelope |
-| `Node.kt:StreamSource.inferOutputSchema()` | Calls unwrapCdc() when flag is set |
-| `AvroExt.kt` | Preserves null values for before/after fields |
-
-### Proto Definition
-
-```protobuf
-message StreamSourceNode {
-  DataStreamProto data_stream = 1;
-  Encoding encoding = 2;
-  bool unwrap_cdc = 3;  // Extract 'after' payload from CDC envelope
-}
-```
-
 ## Kafka Connect Sink (JDBC)
 
-TypeStream creates JDBC sink connectors via Kafka Connect to write processed data to databases. The architecture uses a secure server-side credential resolution pattern.
-
-### Architecture
-
-```
-┌─────────────────────────────────────────────────────────────────┐
-│                          UI (Client)                            │
-│  DbSinkNode configured with:                                    │
-│   - connectionId (reference, no credentials)                    │
-│   - tableName, insertMode, primaryKeyFields                     │
-└───────────────────────────┬─────────────────────────────────────┘
-                            │ CreateJobFromGraphRequest
-                            │ (includes DbSinkConfig list)
-                            ▼
-┌─────────────────────────────────────────────────────────────────┐
-│                     JobService.createJobFromGraph()             │
-│  1. Compiles pipeline graph to Program                          │
-│  2. Starts Kafka Streams job                                    │
-│  3. For each DbSinkConfig:                                      │
-│     - Generates intermediate topic name                         │
-│     - Calls ConnectionService.createJdbcSinkConnector()         │
-└───────────────────────────┬─────────────────────────────────────┘
-                            │
-                            ▼
-┌─────────────────────────────────────────────────────────────────┐
-│               ConnectionService.createJdbcSinkConnector()       │
-│  1. Looks up connection by ID (has credentials)                 │
-│  2. Builds JDBC connector config:                               │
-│     - connector.class: io.debezium.connector.jdbc.JdbcSinkConnector
-│     - connection.url: jdbc:postgresql://...                     │
-│     - value.converter: AvroConverter                            │
-│     - transforms.unwrap: ExtractNewRecordState                  │
-│  3. POSTs config to Kafka Connect REST API                      │
-└───────────────────────────┬─────────────────────────────────────┘
-                            │ POST /connectors
-                            ▼
-┌─────────────────────────────────────────────────────────────────┐
-│                      Kafka Connect                              │
-│  JdbcSinkConnector consumes from intermediate topic             │
-│  and writes to target database table                            │
-└─────────────────────────────────────────────────────────────────┘
-```
+TypeStream creates JDBC sink connectors via Kafka Connect to write processed data to databases.
 
 ### Security Model
 
@@ -306,77 +234,48 @@ Server → Kafka Connect: Full JDBC URL with credentials
 
 ```
 Kafka Streams Job                    Kafka Connect
-        ↓                                  ↓
 [StreamSource] → [Transform] → [Sink]     [JdbcSinkConnector]
                                 ↓              ↓
-                        intermediate_topic ───────────→ Database Table
+                        intermediate_topic ──→ Database Table
 ```
 
-### Proto Definitions
+If connector creation fails, `JobService` performs rollback by killing the job and deleting any created connectors.
 
-```protobuf
-// In job.proto - Sent from client (no credentials)
-message DbSinkConfig {
-  string node_id = 1;
-  string connection_id = 2;        // Server resolves credentials
-  string table_name = 3;
-  string insert_mode = 4;          // insert, upsert, update
-  string primary_key_fields = 5;
-  string intermediate_topic = 6;   // Optional - auto-generated if empty
-}
+## Integration Points
 
-// In connection.proto - Internal server request
-message CreateJdbcSinkConnectorRequest {
-  string connection_id = 1;
-  string connector_name = 2;
-  string topics = 3;
-  string table_name = 4;
-  string insert_mode = 5;
-  string primary_key_fields = 6;
-}
-```
+### Kafka (Redpanda)
+- **Streams**: `KafkaStreamsJob` creates `KafkaStreams` instances with `StreamsBuilder` topology
+- **Admin**: `PipelineStateStore` creates and manages the `__typestream_pipelines` compacted topic
+- **Producer/Consumer**: `PipelineStateStore` uses raw Kafka producer/consumer for state persistence
 
-### Connector Configuration
+### Schema Registry
+- **Read path**: `SchemaRegistryClient` fetches writer schemas by ID for deserialization
+- **Write path**: `AvroSerde` registers schemas when producing to new topics
+- **Catalog sync**: `FileSystem` watches Schema Registry for metadata changes
 
-The JDBC sink connector is configured with:
+### Kafka Connect
+- **REST API**: `ConnectionService.createKafkaConnectConnector()` POSTs connector configs
+- **Connector types**: JDBC Sink (`io.debezium.connector.jdbc.JdbcSinkConnector`), Weaviate Sink, Elasticsearch Sink
 
-| Config | Value |
-|--------|-------|
-| `connector.class` | `io.debezium.connector.jdbc.JdbcSinkConnector` |
-| `value.converter` | `io.confluent.connect.avro.AvroConverter` |
-| `transforms.unwrap.type` | `io.debezium.transforms.ExtractNewRecordState` |
-| `schema.evolution` | `basic` |
-| `insert.mode` | `insert`, `upsert`, or `update` |
+### gRPC Clients (UI, CLI)
+- Server listens on configurable port (default 8080)
+- Connect Protocol (gRPC-Web) for browser clients via Envoy proxy
+- Native gRPC for CLI clients
 
-### Rollback Handling
-
-If connector creation fails, JobService performs rollback:
-
-```kotlin
-private fun rollbackJobAndConnectors(jobId: String, connectorNames: List<String>) {
-    vm.scheduler.kill(jobId)
-    connectorNames.forEach { deleteKafkaConnectConnector(it) }
-}
-```
-
-### Key Files
-
-| File | Function |
-|------|----------|
-| `JobService.kt:createJobFromGraph()` | Orchestrates job + connector creation |
-| `ConnectionService.kt:createJdbcSinkConnector()` | Builds and deploys connector |
-| `ConnectionService.kt:buildJdbcSinkConnectorConfig()` | Constructs connector JSON |
-| `ConnectionService.kt:createKafkaConnectConnector()` | HTTP POST to Connect API |
+### External Services
+- **GeoIP**: MaxMind GeoLite2 database for IP geolocation enrichment
+- **OpenAI**: REST API for embedding generation and LLM transformations
 
 ## Integration Tests
 
-Integration tests use **Testcontainers with real Kafka** to verify pipelines end-to-end.
+Integration tests use **Testcontainers with real Kafka** (Redpanda) to verify pipelines end-to-end.
 
 ### Test Infrastructure
 
-- Tests spin up real Kafka containers via `TestKafka()` helper
-- Pipelines are built programmatically using `Job.PipelineNode` and `Job.PipelineEdge`
-- gRPC services are tested via in-process servers (`InProcessServerBuilder`)
+- `TestKafkaContainer.instance` singleton provides a shared Redpanda container
+- `TestKafka.uniqueTopic("name")` generates isolated topic names per test
+- `testKafka.produceRecords(topic, encoding, records...)` for test data
+- gRPC services tested via `InProcessServerBuilder` + `GrpcCleanupRule`
 
 ### Key Test Files
 
@@ -385,6 +284,8 @@ Integration tests use **Testcontainers with real Kafka** to verify pipelines end
 | `GraphCompilerTest.kt` | Graph compilation, schema propagation through node chains |
 | `PreviewJobIntegrationTest.kt` | End-to-end message flow via gRPC streaming |
 | `JobServiceTest.kt` | Graph-to-job creation via gRPC |
+| `PipelineServiceTest.kt` | Pipeline CRUD, plan/diff, state persistence |
+| `PipelineStateStoreTest.kt` | State store load/save/delete with real Kafka |
 | `StateQueryServiceTest.kt` | State stores and interactive queries on running pipelines |
 
 ### Adding Tests for New Nodes
@@ -394,9 +295,8 @@ When adding a new node type, add integration tests that verify:
 1. **Schema propagation**: Test that `inferNodeSchemasForUI()` correctly propagates schemas through your node
    - See `GraphCompilerTest.inferNodeSchemasForUI propagates schemas through chain`
 2. **Graph compilation**: Test that `GraphCompiler.compile()` handles your node in a pipeline
-   - Build a graph with `StreamSource → YourNode → Sink` and verify it compiles
+   - Build a graph with `StreamSource -> YourNode -> Sink` and verify it compiles
 3. **Message flow** (if the node transforms data): Test in `PreviewJobIntegrationTest` that messages flow through correctly
-   - Produce test data, run a preview job, verify output via gRPC streaming
 
 ### Example Test Pattern
 
@@ -424,12 +324,15 @@ fun `compiles stream source with your node`() {
 
 | File | Purpose |
 |------|---------|
-| `Compiler.kt` | Text → Graph compilation |
-| `GraphCompiler.kt` | Proto → Graph compilation |
+| `Compiler.kt` | Text -> Graph compilation |
+| `GraphCompiler.kt` | Proto -> Graph compilation |
+| `PipelineGraphEmitter.kt` | DSL -> PipelineGraph proto conversion |
 | `Interpreter.kt` | AST traversal, type binding |
 | `Node.kt` | Node types with schema inference |
 | `KafkaStreamsJob.kt` | Topology builder, job execution |
 | `Scheduler.kt` | Job queue and lifecycle |
 | `Vm.kt` | Execution routing (KAFKA vs SHELL) |
+| `PipelineService.kt` | Pipeline CRUD, plan/diff, recovery |
+| `PipelineStateStore.kt` | Kafka compacted topic state persistence |
 | `ConnectionService.kt` | JDBC connection monitoring and sink connector management |
 | `DataStreamSerde.kt` | Kafka serialization |


### PR DESCRIPTION
## Summary

- Create root `ARCHITECTURE.md` with system overview, pipeline lifecycle (all 4 entry points), complete node reference (18 types), schema propagation, build system, infrastructure, and CI/CD sections
- Create `cli/ARCHITECTURE.md` covering Go CLI (Cobra commands, Docker Compose orchestration, pipeline-as-code, proto generation)
- Create `protos/ARCHITECTURE.md` covering all 6 gRPC services, PipelineGraph data model, and code generation targets
- Update `server/ARCHITECTURE.md` to slim down cross-cutting content (moved to root), add PipelineService/PipelineStateStore docs, add cross-references
- Update `uiv2/ARCHITECTURE.md` with node type mapping table (React Flow → proto), updated features, cross-references
- Update `connectors/demo-data/ARCHITECTURE.md` with FileUploads connector, CDC data flow, cross-references
- Update `CLAUDE.md` architecture section to link to full doc tree
- Add advisory staleness check to post-task hook (warns when component code changes without ARCHITECTURE.md update)

## Document Tree

```
ARCHITECTURE.md                       # NEW  - system overview + cross-cutting concepts
server/ARCHITECTURE.md                # UPDATED - slimmed, cross-refs to root
uiv2/ARCHITECTURE.md                  # UPDATED - node type mapping, cross-refs
cli/ARCHITECTURE.md                   # NEW  - Go CLI
protos/ARCHITECTURE.md                # NEW  - API contracts
connectors/demo-data/ARCHITECTURE.md  # UPDATED - cross-refs, FileUploads
```

## Test plan
- [ ] Verify all markdown links resolve correctly (relative paths between docs)
- [ ] Each child doc has a back-link to root (`> Part of [TypeStream Architecture]`)
- [ ] Root doc links to all children in Component Docs section
- [ ] Node reference covers all 18 node types from `Node.kt`
- [ ] Pipeline lifecycle shows all 4 entry points (GUI, CLI config, CLI run, shell)
- [ ] Hook runs without errors on git status output