### PR TITLE
fix: cancel kafka watcher coroutines on server shutdown

### DIFF
--- a/server/src/main/kotlin/io/typestream/filesystem/FileSystem.kt
+++ b/server/src/main/kotlin/io/typestream/filesystem/FileSystem.kt
@@ -45,7 +45,7 @@ class FileSystem(val config: Config, private val dispatcher: CoroutineDispatcher
     init {
         config.sources.kafka.forEach { (name, config) ->
             logger.info { "starting filesystem for kafka cluster: $name" }
-            kafkaDir.add(KafkaClusterDirectory(name, config, dispatcher))
+            kafkaDir.add(KafkaClusterDirectory(name, config))
         }
         config.mounts.random.values.forEach { (valueType, endpoint) ->
             randomDir.add(Random(endpoint.substringAfterLast("/"), valueType))


### PR DESCRIPTION
## Summary

- `KafkaClusterDirectory.watch()` created an independent `CoroutineScope` whose 4 tick coroutines were never cancelled. Each test leaked 4 zombie polling loops that kept hitting Kafka, saturating it after 20+ tests and causing later tests to take 44-46s for trivial operations.
- Fix: launch ticks as children of the existing `supervisorScope` so they cancel automatically via structured concurrency when `FileSystem.close()` is called.
- Merged the separate `CoroutineExceptionHandler` and `networkExceptionHandler` into a single handler that logs all errors without re-throwing, keeping watchers resilient across transient failures.

## Test plan

- [x] `./gradlew :server:compileKotlin` passes
- [x] `./gradlew :server:compileTestKotlin` passes
- [x] CI integration tests pass (gRPC tests should be faster with no zombie coroutines)