### PR TITLE
fix: Add missing test packages and proto paths to CI

### DIFF
--- a/.github/workflows/cli-lint.yml
+++ b/.github/workflows/cli-lint.yml
@@ -5,6 +5,7 @@ on:
     branches: [main]
     paths:
       - 'cli/**'
+      - 'protos/**'
       - 'flake.nix'
       - 'flake.lock'
       - '.github/workflows/cli-lint.yml'
@@ -12,6 +13,7 @@ on:
     branches: [main]
     paths:
       - 'cli/**'
+      - 'protos/**'
       - 'flake.nix'
       - 'flake.lock'
       - '.github/workflows/cli-lint.yml'

--- a/.github/workflows/server-check.yml
+++ b/.github/workflows/server-check.yml
@@ -55,7 +55,7 @@ jobs:
           - test-group: grpc
             tests: "--tests 'io.typestream.grpc.*'"
           - test-group: other
-            tests: "--tests 'io.typestream.filesystem.*' --tests 'io.typestream.kafka.*' --tests 'io.typestream.geoip.*' --tests 'io.typestream.textextractor.*' --tests 'io.typestream.embedding.*'"
+            tests: "--tests 'io.typestream.filesystem.*' --tests 'io.typestream.kafka.*' --tests 'io.typestream.geoip.*' --tests 'io.typestream.textextractor.*' --tests 'io.typestream.embedding.*' --tests 'io.typestream.pipeline.*' --tests 'io.typestream.server.*' --tests 'io.typestream.helpers.*'"
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Summary

- **server-check**: Add `io.typestream.pipeline.*`, `io.typestream.server.*`, and `io.typestream.helpers.*` to the `other` test group — these packages were never running in CI
- **cli-lint**: Add `protos/**` path trigger so proto changes also lint the Go CLI (server-check and frontend-check already had this)

## Context

Proto changes impact all downstream consumers (server, CLI, UI). The server and frontend workflows already triggered on `protos/**`, but the CLI workflow did not. Additionally, the server test matrix was missing 3 test packages entirely.

## Test plan

- [x] Verify no test packages are missing by cross-referencing `server/src/test/kotlin/io/typestream/` packages against CI matrix