### PR TITLE
feat: Update hero to Terraform for Kafka Streams positioning

### DIFF
--- a/website/src/index.html
+++ b/website/src/index.html
@@ -498,15 +498,13 @@
       <div class="container relative">
         <div class="max-w-3xl mx-auto text-center">
           <h1 class="text-4xl lg:text-6xl font-bold text-slate-900 dark:text-white mb-6 leading-tight">
-            You already run Kafka.<br>
-            <span class="text-indigo-600 dark:text-indigo-400">Start building on it.</span>
+            Terraform for <span class="text-indigo-600 dark:text-indigo-400">Kafka Streams.</span>
           </h1>
 
           <p class="text-xl lg:text-2xl text-slate-600 dark:text-slate-400 leading-relaxed mb-10 max-w-2xl mx-auto">
-            TypeStream compiles pipeline configs into Kafka Streams topologies.
-            Filter, join, enrich, and route your topics -- defined in a config
-            file, previewed with <code class="text-indigo-600 dark:text-indigo-400 font-semibold">typestream plan</code>,
-            deployed in seconds. No Java. No new microservices.
+            Declare pipelines in config. Preview changes with <code class="text-indigo-600 dark:text-indigo-400 font-semibold">typestream plan</code>.
+            Deploy native Kafka Streams topologies with <code class="text-indigo-600 dark:text-indigo-400 font-semibold">typestream apply</code>.
+            No JVM code. No new infrastructure.
           </p>
 
           <div class="flex flex-col sm:flex-row gap-4 justify-center mb-4">


### PR DESCRIPTION
## Summary
- Replaced H1 heading from "You already run Kafka. Start building on it." to "Terraform for Kafka Streams." with indigo accent on "Kafka Streams."
- Rewrote sub-hero paragraph to reference `typestream plan` and `typestream apply`, matching the Terraform analogy
- Tightened closing line to "No JVM code. No new infrastructure."

## Test plan
- [ ] Run `cd website && npm run dev` and verify hero section renders correctly
- [ ] Check dark mode styling for the indigo accent span
- [ ] Verify responsive layout on mobile (text wrapping)