### PR TITLE
feat(server): make pipeline failures crash-restartable so k8s self-heals

### DIFF
--- a/cli/cmd/root_test.go
+++ b/cli/cmd/root_test.go
@@ -40,7 +40,7 @@ func TestResolveServerAddress_FlagTakesPrecedence(t *testing.T) {
 }
 
 func TestResolveServerAddress_Missing(t *testing.T) {
-	os.Unsetenv("TYPESTREAM_SERVER")
+	_ = os.Unsetenv("TYPESTREAM_SERVER")
 
 	_, err := resolveServerAddress("")
 	if err == nil {

--- a/cli/pkg/k8s/typestream.yaml.tmpl
+++ b/cli/pkg/k8s/typestream.yaml.tmpl
@@ -89,6 +89,12 @@ spec:
             - containerPort: 4242
               hostPort: 4242
               protocol: TCP
+          livenessProbe:
+            grpc:
+              port: 4242
+            initialDelaySeconds: 30
+            periodSeconds: 30
+            failureThreshold: 3
           resources:
             limits:
               cpu: "4"

--- a/cli/pkg/k8s/typestream.yaml.tmpl
+++ b/cli/pkg/k8s/typestream.yaml.tmpl
@@ -89,10 +89,16 @@ spec:
             - containerPort: 4242
               hostPort: 4242
               protocol: TCP
+          # Gate liveness on startup: a slow boot (pipeline recovery, slow Kafka) gets up to
+          # ~300s to bind the gRPC port and become healthy before the liveness probe can fire.
+          startupProbe:
+            grpc:
+              port: 4242
+            periodSeconds: 10
+            failureThreshold: 30
           livenessProbe:
             grpc:
               port: 4242
-            initialDelaySeconds: 30
             periodSeconds: 30
             failureThreshold: 3
           resources:

--- a/config/src/main/kotlin/io/typestream/config/Config.kt
+++ b/config/src/main/kotlin/io/typestream/config/Config.kt
@@ -40,14 +40,18 @@ data class Config(
             // Not convinced this should be public for now (which is why it's not officially documented)
             val systemConfigPath = SystemEnv["TYPESTREAM_SYSTEM_CONFIG_PATH"] ?: "/etc/typestream"
 
-            var kubernetesMode = false
+            // DNS detection only drives copying the mounted /config into the system config
+            // path for in-cluster deployments. It does NOT enable the K8s-Job scheduler/watcher;
+            // that is the explicit `k8sMode` config flag (see below), so in-process deployments
+            // don't trigger the unfinished worker-job path (and its `list jobs` 403).
+            var inCluster = false
             try {
                 InetAddress.getByName("kubernetes.default.svc")
-                kubernetesMode = true
+                inCluster = true
             } catch (_: Exception) {
             }
 
-            if (kubernetesMode) {
+            if (inCluster) {
                 logger.info { "copy config from /config into /etc/typestream" }
                 val configFile = Paths.get("/config", "typestream.toml").toFile()
                 val systemConfigFile = Paths.get(systemConfigPath, "typestream.toml").toFile()
@@ -113,7 +117,7 @@ data class Config(
                 tomlConfig.sources,
                 tomlConfig.grpc,
                 tomlConfig.mounts,
-                kubernetesMode,
+                tomlConfig.k8sMode,
                 versionInfo,
                 configFilePath
             )

--- a/config/src/main/kotlin/io/typestream/config/TomlConfig.kt
+++ b/config/src/main/kotlin/io/typestream/config/TomlConfig.kt
@@ -1,11 +1,17 @@
 package io.typestream.config
 
 import kotlinx.serialization.Serializable
+import kotlinx.serialization.builtins.serializer
 import net.peanuuutz.tomlkt.Toml
 import net.peanuuutz.tomlkt.TomlTable
 
 @Serializable
-data class TomlConfig(val sources: SourcesConfig, val grpc: GrpcConfig, val mounts: MountsConfig) {
+data class TomlConfig(
+    val sources: SourcesConfig,
+    val grpc: GrpcConfig,
+    val mounts: MountsConfig,
+    val k8sMode: Boolean = false,
+) {
     fun mergeWith(mountsConfig: MountsConfig) {
         mounts.random.putAll(mountsConfig.random)
     }
@@ -30,8 +36,11 @@ data class TomlConfig(val sources: SourcesConfig, val grpc: GrpcConfig, val moun
                 MountsConfig(random = mutableMapOf())
             }
 
+            val k8sMode = toml["k8sMode"]?.let {
+                Toml.decodeFromTomlElement(Boolean.serializer(), it)
+            } ?: false
 
-            return TomlConfig(sources, grpc, mounts)
+            return TomlConfig(sources, grpc, mounts, k8sMode)
         }
     }
 }

--- a/config/src/test/kotlin/io/typestream/config/ConfigTest.kt
+++ b/config/src/test/kotlin/io/typestream/config/ConfigTest.kt
@@ -68,6 +68,27 @@ internal class ConfigTest {
     }
 
     @Test
+    fun `k8sMode is an explicit config flag`() {
+        val tempDir = createTempDirectory()
+
+        every { SystemEnv["TYPESTREAM_SYSTEM_CONFIG_PATH"] } returns "$tempDir/typestream"
+
+        every { SystemEnv["TYPESTREAM_CONFIG"] } returns """
+            k8sMode=true
+            [grpc]
+            port=4242
+            [sources.kafka.local]
+            bootstrapServers="localhost:9092"
+            schemaRegistry.url="http://localhost:8081"
+            fsRefreshRate=1
+        """.trimIndent()
+
+        val config = Config.fetch()
+
+        assertThat(config.k8sMode).isTrue()
+    }
+
+    @Test
     fun `loads defaults`() {
         val tempDir = createTempDirectory()
 

--- a/server/src/main/kotlin/io/typestream/Server.kt
+++ b/server/src/main/kotlin/io/typestream/Server.kt
@@ -21,6 +21,7 @@ import io.typestream.server.StateQueryService
 import io.typestream.pipeline.PipelineStateStore
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import java.io.Closeable
@@ -39,6 +40,10 @@ class Server(
     var server: Server? = null
 
     private val subSystems = mutableListOf<Closeable>()
+
+    // The health monitor is a long-running loop (not a Closeable), so close() must cancel it
+    // explicitly; otherwise run()'s runBlocking never completes after shutdown (it joins this child).
+    private var healthMonitorJob: Job? = null
 
     fun run(serverBuilder: ServerBuilder<*> = ServerBuilder.forPort(config.grpc.port)) = runBlocking {
         val fileSystem = FileSystem(config, dispatcher)
@@ -100,7 +105,7 @@ class Server(
             graceWindow = healthGraceWindow,
             interval = healthPollInterval,
         )
-        launch(dispatcher) {
+        healthMonitorJob = launch(dispatcher) {
             healthMonitor.run()
         }
 
@@ -112,6 +117,7 @@ class Server(
 
     override fun close() {
         logger.info { "shutting down grpc server" }
+        healthMonitorJob?.cancel()
         server?.shutdown()
 
         logger.info { "shutting down sub-systems" }

--- a/server/src/main/kotlin/io/typestream/Server.kt
+++ b/server/src/main/kotlin/io/typestream/Server.kt
@@ -31,7 +31,7 @@ import kotlin.time.Duration.Companion.seconds
 class Server(
     private val config: Config,
     private val dispatcher: CoroutineDispatcher = Dispatchers.IO,
-    private val healthGraceWindow: Duration = 5.minutes,
+    private val healthGraceWindow: Duration = 15.minutes,
     private val healthPollInterval: Duration = 15.seconds,
 ) : Closeable {
     private val logger = KotlinLogging.logger {}

--- a/server/src/main/kotlin/io/typestream/Server.kt
+++ b/server/src/main/kotlin/io/typestream/Server.kt
@@ -4,9 +4,11 @@ import io.github.oshai.kotlinlogging.KotlinLogging
 import io.grpc.Server
 import io.grpc.ServerBuilder
 import io.grpc.protobuf.services.ProtoReflectionService
+import io.grpc.services.HealthStatusManager
 import io.typestream.compiler.vm.Vm
 import io.typestream.config.Config
 import io.typestream.filesystem.FileSystem
+import io.typestream.health.HealthMonitor
 import io.typestream.scheduler.Scheduler
 import io.typestream.server.ExceptionInterceptor
 import io.typestream.server.ConnectionService
@@ -22,8 +24,16 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import java.io.Closeable
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.minutes
+import kotlin.time.Duration.Companion.seconds
 
-class Server(private val config: Config, private val dispatcher: CoroutineDispatcher = Dispatchers.IO) : Closeable {
+class Server(
+    private val config: Config,
+    private val dispatcher: CoroutineDispatcher = Dispatchers.IO,
+    private val healthGraceWindow: Duration = 5.minutes,
+    private val healthPollInterval: Duration = 15.seconds,
+) : Closeable {
     private val logger = KotlinLogging.logger {}
 
     var server: Server? = null
@@ -78,7 +88,21 @@ class Server(private val config: Config, private val dispatcher: CoroutineDispat
         serverBuilder.addService(StateQueryService(vm))
 
         serverBuilder.addService(ProtoReflectionService.newInstance())
-        //TODO add health check. See https://github.com/grpc/grpc/blob/master/doc/health-checking.md
+
+        // Surface pipeline health over the standard gRPC health protocol so a k8s liveness probe
+        // can restart a pod whose pipelines have failed or wedged.
+        // See https://github.com/grpc/grpc/blob/master/doc/health-checking.md
+        val health = HealthStatusManager()
+        serverBuilder.addService(health.healthService)
+        val healthMonitor = HealthMonitor(
+            jobStates = { scheduler.ps().map { it.id to it.state() } },
+            healthManager = health,
+            graceWindow = healthGraceWindow,
+            interval = healthPollInterval,
+        )
+        launch(dispatcher) {
+            healthMonitor.run()
+        }
 
         server = serverBuilder.build()
         server?.start()

--- a/server/src/main/kotlin/io/typestream/coroutine/tick.kt
+++ b/server/src/main/kotlin/io/typestream/coroutine/tick.kt
@@ -7,17 +7,36 @@ import kotlinx.coroutines.launch
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.seconds
 
+/**
+ * Computes the next delay between ticks. On success it resets to [base]; on failure it grows the
+ * [current] delay by [factor], capped at [maxBackoff]. With the default [maxBackoff] == [base] this
+ * is a no-op (fixed interval), preserving the original behaviour.
+ */
+internal fun nextTickDelay(
+    current: Duration,
+    base: Duration,
+    factor: Double,
+    maxBackoff: Duration,
+    failed: Boolean,
+): Duration = if (failed) (current * factor).coerceAtMost(maxBackoff) else base
+
 fun CoroutineScope.tick(
     duration: Duration = 60.seconds,
     exceptionHandler: (Throwable) -> Unit = { throw it },
+    maxBackoff: Duration = duration,
+    factor: Double = 1.2,
     callback: () -> Unit,
 ) = this.launch {
+    var currentDelay = duration
     while (isActive) {
-        try {
+        val failed = try {
             callback()
+            false
         } catch (e: Throwable) {
             exceptionHandler(e)
+            true
         }
-        delay(duration)
+        currentDelay = nextTickDelay(currentDelay, duration, factor, maxBackoff, failed)
+        delay(currentDelay)
     }
 }

--- a/server/src/main/kotlin/io/typestream/filesystem/kafka/KafkaClusterDirectory.kt
+++ b/server/src/main/kotlin/io/typestream/filesystem/kafka/KafkaClusterDirectory.kt
@@ -85,19 +85,35 @@ class KafkaClusterDirectory(
 
     override suspend fun watch(): Unit = supervisorScope {
         val fsRefreshRate = kafkaConfig.fsRefreshRate.seconds
-        logger.info { "launching kafka watchers (rate: $fsRefreshRate seconds)" }
+        logger.info { "launching kafka watchers (rate: $fsRefreshRate)" }
 
+        // A broker outage makes every watcher tick fail. Don't flood the logs with a full stack
+        // trace per tick (the 2026-05-31 incident produced ~18.9k of them): log the first
+        // occurrence (and any change of error) at warn, and keep the rest at debug. Combined with
+        // the exponential backoff below, a transient blip stays quiet.
+        var lastTransientFailure: String? = null
         val exceptionHandler: (Throwable) -> Unit = { exception ->
-            when (exception) {
-                is java.net.ConnectException -> logger.debug(exception) { "kafka cluster directory watcher failed" }
-                else -> logger.error(exception) { "kafka cluster directory watcher failed" }
+            if (isTransientBrokerException(exception)) {
+                val signature = exception::class.qualifiedName
+                if (signature != lastTransientFailure) {
+                    lastTransientFailure = signature
+                    logger.warn { "kafka cluster '$name' is unreachable, backing off: ${exception.message}" }
+                } else {
+                    logger.debug(exception) { "kafka cluster directory watcher still failing" }
+                }
+            } else {
+                lastTransientFailure = null
+                logger.error(exception) { "kafka cluster directory watcher failed" }
             }
         }
 
-        tick(fsRefreshRate, exceptionHandler) { refreshConsumerGroupsDir() }
-        tick(fsRefreshRate, exceptionHandler) { refreshBrokersDir() }
-        tick(fsRefreshRate, exceptionHandler) { refreshTopicsDir() }
-        tick(fsRefreshRate, exceptionHandler) { refreshSchemaRegistryDir() }
+        // Back off up to ~10x the refresh rate while the cluster stays unreachable.
+        val maxBackoff = fsRefreshRate * 10
+
+        tick(fsRefreshRate, exceptionHandler, maxBackoff) { refreshConsumerGroupsDir() }
+        tick(fsRefreshRate, exceptionHandler, maxBackoff) { refreshBrokersDir() }
+        tick(fsRefreshRate, exceptionHandler, maxBackoff) { refreshTopicsDir() }
+        tick(fsRefreshRate, exceptionHandler, maxBackoff) { refreshSchemaRegistryDir() }
     }
 
     override fun refresh() {
@@ -134,4 +150,23 @@ class KafkaClusterDirectory(
         logger.debug { "$name schema registry refresh" }
         schemaRegistryDir.replaceAll(schemaRegistryClient.subjects().keys.map { t -> Directory(t) })
     }
+}
+
+/**
+ * Whether [throwable] (or any of its causes) is a transient broker-connectivity failure — a
+ * connection refusal or a Kafka client error/timeout — as opposed to an unexpected bug. Admin
+ * client calls surface these wrapped in [java.util.concurrent.ExecutionException], so we walk the
+ * cause chain. `org.apache.kafka.common.errors.TimeoutException` is a `KafkaException`, so the
+ * `KafkaException` check covers broker timeouts too.
+ */
+internal fun isTransientBrokerException(throwable: Throwable): Boolean {
+    var e: Throwable? = throwable
+    while (e != null) {
+        when (e) {
+            is java.net.ConnectException,
+            is org.apache.kafka.common.KafkaException -> return true
+        }
+        e = e.cause
+    }
+    return false
 }

--- a/server/src/main/kotlin/io/typestream/health/HealthMonitor.kt
+++ b/server/src/main/kotlin/io/typestream/health/HealthMonitor.kt
@@ -1,0 +1,75 @@
+package io.typestream.health
+
+import io.github.oshai.kotlinlogging.KotlinLogging
+import io.grpc.health.v1.HealthCheckResponse.ServingStatus
+import io.grpc.services.HealthStatusManager
+import io.typestream.scheduler.Job
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.isActive
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.minutes
+import kotlin.time.Duration.Companion.seconds
+
+/**
+ * Periodically derives an overall gRPC serving status from the scheduler's managed jobs and pushes
+ * it to [healthManager], so a Kubernetes liveness probe can restart a pod whose pipelines have
+ * wedged or failed.
+ *
+ * The predicate is intentionally state-based (see [evaluate]): a job that is `FAILED`, or that has
+ * been present-but-not-`RUNNING` for longer than [graceWindow], makes the whole server report
+ * `NOT_SERVING`. The grace window absorbs normal startup and rebalancing (both surface as a
+ * non-`RUNNING` state) without false positives. It deliberately does not cover a thread that hangs
+ * while still reporting `RUNNING` — that needs a lag/progress check (see the plan's Deferred notes).
+ *
+ * @param jobStates the live `(id, state)` of every managed job, e.g. `{ scheduler.ps().map { it.id to it.state() } }`
+ */
+class HealthMonitor(
+    private val jobStates: () -> List<Pair<String, Job.State>>,
+    private val healthManager: HealthStatusManager,
+    private val graceWindow: Duration = 5.minutes,
+    private val interval: Duration = 15.seconds,
+    private val clock: () -> Long = System::currentTimeMillis,
+) {
+    private val logger = KotlinLogging.logger {}
+
+    // Per job id, the last time we observed it RUNNING (or first saw it). Used to grant a grace
+    // window before a persistently non-RUNNING job is treated as unhealthy.
+    private val lastHealthyAt = mutableMapOf<String, Long>()
+
+    suspend fun run() = coroutineScope {
+        while (isActive) {
+            val status = evaluate()
+            healthManager.setStatus(HealthStatusManager.SERVICE_NAME_ALL_SERVICES, status)
+            delay(interval)
+        }
+    }
+
+    internal fun evaluate(): ServingStatus {
+        val now = clock()
+        val states = jobStates()
+
+        // Forget jobs that are no longer managed so the map doesn't grow unbounded.
+        lastHealthyAt.keys.retainAll(states.map { it.first }.toSet())
+
+        var healthy = true
+        for ((id, state) in states) {
+            when (state) {
+                Job.State.RUNNING -> lastHealthyAt[id] = now
+                Job.State.FAILED -> {
+                    logger.warn { "job $id is FAILED; reporting NOT_SERVING" }
+                    healthy = false
+                }
+                else -> {
+                    val since = lastHealthyAt.getOrPut(id) { now }
+                    if (now - since > graceWindow.inWholeMilliseconds) {
+                        logger.warn { "job $id has been $state past the grace window; reporting NOT_SERVING" }
+                        healthy = false
+                    }
+                }
+            }
+        }
+
+        return if (healthy) ServingStatus.SERVING else ServingStatus.NOT_SERVING
+    }
+}

--- a/server/src/main/kotlin/io/typestream/health/HealthMonitor.kt
+++ b/server/src/main/kotlin/io/typestream/health/HealthMonitor.kt
@@ -4,6 +4,7 @@ import io.github.oshai.kotlinlogging.KotlinLogging
 import io.grpc.health.v1.HealthCheckResponse.ServingStatus
 import io.grpc.services.HealthStatusManager
 import io.typestream.scheduler.Job
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.isActive
@@ -27,7 +28,7 @@ import kotlin.time.Duration.Companion.seconds
 class HealthMonitor(
     private val jobStates: () -> List<Pair<String, Job.State>>,
     private val healthManager: HealthStatusManager,
-    private val graceWindow: Duration = 5.minutes,
+    private val graceWindow: Duration = 15.minutes,
     private val interval: Duration = 15.seconds,
     private val clock: () -> Long = System::currentTimeMillis,
 ) {
@@ -39,8 +40,18 @@ class HealthMonitor(
 
     suspend fun run() = coroutineScope {
         while (isActive) {
-            val status = evaluate()
-            healthManager.setStatus(HealthStatusManager.SERVICE_NAME_ALL_SERVICES, status)
+            try {
+                val status = evaluate()
+                healthManager.setStatus(HealthStatusManager.SERVICE_NAME_ALL_SERVICES, status)
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Exception) {
+                // A transient failure to read job state (e.g. a concurrent-modification race in
+                // scheduler.ps()) must not crash the monitor — its launch is a child of the server's
+                // root scope, so an escaping exception would cancel the whole gRPC server. Leave the
+                // last reported status in place and re-evaluate next tick.
+                logger.warn(e) { "health evaluation failed; leaving serving status unchanged" }
+            }
             delay(interval)
         }
     }

--- a/server/src/main/kotlin/io/typestream/scheduler/KafkaStreamsJob.kt
+++ b/server/src/main/kotlin/io/typestream/scheduler/KafkaStreamsJob.kt
@@ -1,5 +1,6 @@
 package io.typestream.scheduler
 
+import io.github.oshai.kotlinlogging.KLogger
 import io.github.oshai.kotlinlogging.KotlinLogging
 import io.typestream.compiler.Program
 import io.typestream.compiler.kafka.KafkaStreamSource
@@ -38,6 +39,7 @@ import org.apache.kafka.common.config.SaslConfigs
 import org.apache.kafka.streams.KafkaStreams
 import org.apache.kafka.streams.StreamsConfig
 import org.apache.kafka.streams.Topology
+import org.apache.kafka.streams.errors.StreamsUncaughtExceptionHandler
 import java.util.Properties
 import kotlin.time.Duration.Companion.seconds
 import kotlin.time.toJavaDuration
@@ -46,6 +48,19 @@ import kotlin.time.toJavaDuration
  * A key-value record from a Kafka topic, used for preview streaming.
  */
 data class PreviewRecord(val key: String, val value: String)
+
+/**
+ * Handler installed on each job's [KafkaStreams] client. A fatal stream-thread error shuts down
+ * this client only ([StreamsUncaughtExceptionHandler.StreamThreadExceptionResponse.SHUTDOWN_CLIENT],
+ * not `SHUTDOWN_APPLICATION`) so one bad job doesn't take its in-process siblings down with it; the
+ * resulting ERROR state surfaces as `Job.State.FAILED`, which the gRPC health check turns into a pod
+ * restart.
+ */
+internal fun streamsUncaughtExceptionHandler(id: String, logger: KLogger) =
+    StreamsUncaughtExceptionHandler { exception ->
+        logger.error(exception) { "$id hit a fatal stream error, shutting down client" }
+        StreamsUncaughtExceptionHandler.StreamThreadExceptionResponse.SHUTDOWN_CLIENT
+    }
 
 
 /**
@@ -210,7 +225,16 @@ class KafkaStreamsJob(
 
     override fun start() {
         val topology = buildTopology()
-        kafkaStreams = KafkaStreams(topology, StreamsConfig(config()))
+        kafkaStreams = KafkaStreams(topology, StreamsConfig(config())).apply {
+            // Without these, a fatal stream error kills the thread silently and the job wedges
+            // invisibly (the 2026-05-31 incident). The state listener gives a diagnostic trail;
+            // the exception handler transitions this client to ERROR (-> Job.State.FAILED) so the
+            // gRPC health check can report NOT_SERVING and Kubernetes can restart the pod.
+            setStateListener { newState, oldState ->
+                logger.info { "${program.id} state $oldState -> $newState" }
+            }
+            setUncaughtExceptionHandler(streamsUncaughtExceptionHandler(program.id, logger))
+        }
         logger.debug { topology.describe().toString() }
 
         logger.info { "starting ${program.id}" }

--- a/server/src/test/kotlin/io/typestream/coroutine/TickTest.kt
+++ b/server/src/test/kotlin/io/typestream/coroutine/TickTest.kt
@@ -1,0 +1,29 @@
+package io.typestream.coroutine
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import kotlin.time.Duration.Companion.seconds
+
+internal class TickTest {
+
+    @Test
+    fun `resets to base delay on success`() {
+        val next = nextTickDelay(current = 8.seconds, base = 1.seconds, factor = 2.0, maxBackoff = 10.seconds, failed = false)
+
+        assertThat(next).isEqualTo(1.seconds)
+    }
+
+    @Test
+    fun `grows delay by factor on failure`() {
+        val next = nextTickDelay(current = 1.seconds, base = 1.seconds, factor = 2.0, maxBackoff = 10.seconds, failed = true)
+
+        assertThat(next).isEqualTo(2.seconds)
+    }
+
+    @Test
+    fun `caps backoff at maxBackoff`() {
+        val next = nextTickDelay(current = 8.seconds, base = 1.seconds, factor = 2.0, maxBackoff = 10.seconds, failed = true)
+
+        assertThat(next).isEqualTo(10.seconds)
+    }
+}

--- a/server/src/test/kotlin/io/typestream/filesystem/kafka/WatcherExceptionTest.kt
+++ b/server/src/test/kotlin/io/typestream/filesystem/kafka/WatcherExceptionTest.kt
@@ -1,0 +1,36 @@
+package io.typestream.filesystem.kafka
+
+import org.apache.kafka.common.KafkaException
+import org.apache.kafka.common.errors.TimeoutException
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.net.ConnectException
+import java.util.concurrent.ExecutionException
+
+internal class WatcherExceptionTest {
+
+    @Test
+    fun `broker timeouts are transient`() {
+        assertThat(isTransientBrokerException(TimeoutException("timed out"))).isTrue()
+    }
+
+    @Test
+    fun `kafka exceptions are transient`() {
+        assertThat(isTransientBrokerException(KafkaException("no brokers"))).isTrue()
+    }
+
+    @Test
+    fun `connect failures are transient`() {
+        assertThat(isTransientBrokerException(ConnectException("connection refused"))).isTrue()
+    }
+
+    @Test
+    fun `unwraps wrapped causes`() {
+        assertThat(isTransientBrokerException(ExecutionException(TimeoutException("timed out")))).isTrue()
+    }
+
+    @Test
+    fun `unexpected exceptions are not transient`() {
+        assertThat(isTransientBrokerException(IllegalStateException("boom"))).isFalse()
+    }
+}

--- a/server/src/test/kotlin/io/typestream/grpc/HealthServiceTest.kt
+++ b/server/src/test/kotlin/io/typestream/grpc/HealthServiceTest.kt
@@ -1,0 +1,100 @@
+package io.typestream.grpc
+
+import io.grpc.health.v1.HealthCheckRequest
+import io.grpc.health.v1.HealthCheckResponse.ServingStatus
+import io.grpc.health.v1.HealthGrpc
+import io.grpc.inprocess.InProcessChannelBuilder
+import io.grpc.inprocess.InProcessServerBuilder
+import io.grpc.testing.GrpcCleanupRule
+import io.typestream.Server
+import io.typestream.config.testing.testConfig
+import io.typestream.grpc.job_service.Job
+import io.typestream.grpc.job_service.JobServiceGrpc
+import io.typestream.testing.TestKafka
+import io.typestream.testing.TestKafkaContainer
+import io.typestream.testing.model.Book
+import io.typestream.testing.until
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Rule
+import org.junit.jupiter.api.Test
+import org.testcontainers.junit.jupiter.Testcontainers
+import java.util.UUID
+import kotlin.time.Duration.Companion.milliseconds
+
+@Testcontainers
+internal class HealthServiceTest {
+    private val dispatcher = Dispatchers.IO
+
+    @get:Rule
+    val grpcCleanupRule: GrpcCleanupRule = GrpcCleanupRule()
+
+    companion object {
+        private val testKafka = TestKafkaContainer.instance
+    }
+
+    @Test
+    fun `reports SERVING when a running pipeline is healthy`(): Unit = runBlocking {
+        val topic = TestKafka.uniqueTopic("books")
+        // Poll fast so the monitor re-evaluates job state quickly during the test.
+        val app = Server(testConfig(testKafka), dispatcher, healthPollInterval = 100.milliseconds)
+
+        app.use {
+            testKafka.produceRecords(
+                topic,
+                "avro",
+                Book(title = "Station Eleven", wordCount = 300, authorId = UUID.randomUUID().toString())
+            )
+
+            val serverName = InProcessServerBuilder.generateName()
+            launch(dispatcher) {
+                app.run(InProcessServerBuilder.forName(serverName).directExecutor())
+            }
+
+            until { requireNotNull(app.server) }
+            grpcCleanupRule.register(app.server ?: return@use)
+
+            val channel = grpcCleanupRule.register(
+                InProcessChannelBuilder.forName(serverName).directExecutor().build()
+            )
+            val jobStub = JobServiceGrpc.newBlockingStub(channel)
+            val healthStub = HealthGrpc.newBlockingStub(channel)
+
+            val streamSource = Job.PipelineNode.newBuilder()
+                .setId("source")
+                .setStreamSource(
+                    Job.StreamSourceNode.newBuilder()
+                        .setDataStream(Job.DataStreamProto.newBuilder().setPath("/dev/kafka/local/topics/$topic"))
+                        .setEncoding(Job.Encoding.AVRO)
+                )
+                .build()
+            val filter = Job.PipelineNode.newBuilder()
+                .setId("filter")
+                .setFilter(
+                    Job.FilterNode.newBuilder()
+                        .setByKey(false)
+                        .setPredicate(Job.PredicateProto.newBuilder().setExpr("Station"))
+                )
+                .build()
+            val graph = Job.PipelineGraph.newBuilder()
+                .addNodes(streamSource)
+                .addNodes(filter)
+                .addEdges(Job.PipelineEdge.newBuilder().setFromId("source").setToId("filter"))
+                .build()
+
+            val response = jobStub.createJobFromGraph(
+                Job.CreateJobFromGraphRequest.newBuilder().setUserId("test-user").setGraph(graph).build()
+            )
+            assertThat(response.success).isTrue()
+
+            val healthRequest = HealthCheckRequest.newBuilder().setService("").build()
+            until("health is SERVING") {
+                require(healthStub.check(healthRequest).status == ServingStatus.SERVING)
+            }
+
+            assertThat(healthStub.check(healthRequest).status).isEqualTo(ServingStatus.SERVING)
+        }
+    }
+}

--- a/server/src/test/kotlin/io/typestream/health/HealthMonitorTest.kt
+++ b/server/src/test/kotlin/io/typestream/health/HealthMonitorTest.kt
@@ -3,9 +3,14 @@ package io.typestream.health
 import io.grpc.health.v1.HealthCheckResponse.ServingStatus
 import io.grpc.services.HealthStatusManager
 import io.typestream.scheduler.Job
+import kotlinx.coroutines.cancelAndJoin
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import kotlin.time.Duration
+import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.minutes
 
 internal class HealthMonitorTest {
@@ -64,5 +69,28 @@ internal class HealthMonitorTest {
         now = 10.minutes.inWholeMilliseconds
         state = Job.State.RUNNING
         assertThat(m.evaluate()).isEqualTo(ServingStatus.SERVING) // running again
+    }
+
+    @Test
+    fun `keeps running when reading job state throws`(): Unit = runBlocking {
+        var explode = true
+        // Models a concurrent-modification race in scheduler.ps(): without the guard in run(), this
+        // exception would escape the launched coroutine and cancel the whole server's root scope.
+        val m = HealthMonitor(
+            jobStates = {
+                if (explode) throw ConcurrentModificationException("ps() race") else listOf("a" to Job.State.RUNNING)
+            },
+            healthManager = HealthStatusManager(),
+            interval = 5.milliseconds,
+            clock = { 0 },
+        )
+
+        val job = launch { m.run() }
+        delay(40) // several ticks while jobStates() throws
+
+        assertThat(job.isActive).isTrue() // a throwing read did not crash the monitor
+
+        explode = false
+        job.cancelAndJoin()
     }
 }

--- a/server/src/test/kotlin/io/typestream/health/HealthMonitorTest.kt
+++ b/server/src/test/kotlin/io/typestream/health/HealthMonitorTest.kt
@@ -1,0 +1,68 @@
+package io.typestream.health
+
+import io.grpc.health.v1.HealthCheckResponse.ServingStatus
+import io.grpc.services.HealthStatusManager
+import io.typestream.scheduler.Job
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.minutes
+
+internal class HealthMonitorTest {
+
+    private fun monitor(
+        grace: Duration = 5.minutes,
+        clock: () -> Long,
+        jobStates: () -> List<Pair<String, Job.State>>,
+    ) = HealthMonitor(jobStates, HealthStatusManager(), graceWindow = grace, clock = clock)
+
+    @Test
+    fun `serving when all jobs are running`() {
+        val m = monitor(clock = { 0 }) { listOf("a" to Job.State.RUNNING, "b" to Job.State.RUNNING) }
+
+        assertThat(m.evaluate()).isEqualTo(ServingStatus.SERVING)
+    }
+
+    @Test
+    fun `not serving when any job failed`() {
+        val m = monitor(clock = { 0 }) { listOf("a" to Job.State.RUNNING, "b" to Job.State.FAILED) }
+
+        assertThat(m.evaluate()).isEqualTo(ServingStatus.NOT_SERVING)
+    }
+
+    @Test
+    fun `tolerates a non-running job within the grace window`() {
+        var now = 0L
+        val m = monitor(grace = 5.minutes, clock = { now }) { listOf("a" to Job.State.STARTING) }
+
+        assertThat(m.evaluate()).isEqualTo(ServingStatus.SERVING)
+        now = 4.minutes.inWholeMilliseconds
+        assertThat(m.evaluate()).isEqualTo(ServingStatus.SERVING)
+    }
+
+    @Test
+    fun `not serving when a job is stuck non-running past the grace window`() {
+        var now = 0L
+        // UNKNOWN is what a stuck restoring/rebalancing job maps to (the incident wedge).
+        val m = monitor(grace = 5.minutes, clock = { now }) { listOf("a" to Job.State.UNKNOWN) }
+
+        assertThat(m.evaluate()).isEqualTo(ServingStatus.SERVING)
+        now = 6.minutes.inWholeMilliseconds
+        assertThat(m.evaluate()).isEqualTo(ServingStatus.NOT_SERVING)
+    }
+
+    @Test
+    fun `recovers to serving when a stuck job starts running again`() {
+        var now = 0L
+        var state = Job.State.RUNNING
+        val m = monitor(grace = 5.minutes, clock = { now }) { listOf("a" to state) }
+
+        m.evaluate() // running at t=0 establishes the baseline
+        now = 3.minutes.inWholeMilliseconds
+        state = Job.State.UNKNOWN
+        assertThat(m.evaluate()).isEqualTo(ServingStatus.SERVING) // within grace
+        now = 10.minutes.inWholeMilliseconds
+        state = Job.State.RUNNING
+        assertThat(m.evaluate()).isEqualTo(ServingStatus.SERVING) // running again
+    }
+}

--- a/server/src/test/kotlin/io/typestream/scheduler/KafkaStreamsJobTest.kt
+++ b/server/src/test/kotlin/io/typestream/scheduler/KafkaStreamsJobTest.kt
@@ -1,0 +1,18 @@
+package io.typestream.scheduler
+
+import io.github.oshai.kotlinlogging.KotlinLogging
+import org.apache.kafka.streams.errors.StreamsUncaughtExceptionHandler
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+internal class KafkaStreamsJobTest {
+
+    @Test
+    fun `uncaught exception handler shuts down the client`() {
+        val handler = streamsUncaughtExceptionHandler("typestream-app-1", KotlinLogging.logger {})
+
+        val response = handler.handle(RuntimeException("fatal stream error"))
+
+        assertThat(response).isEqualTo(StreamsUncaughtExceptionHandler.StreamThreadExceptionResponse.SHUTDOWN_CLIENT)
+    }
+}


### PR DESCRIPTION
## Why

A managed pipeline (`bookkeeper-uncategorized-view`, a `toTable()` materialized view) silently wedged for **26 days** after a ~40-minute transient broker outage. Its Kafka Streams client kept fetching but never advanced its committed offset (stuck restoring/rebalancing), yet the gRPC server stayed up. With **no liveness probe** on the Deployment, Kubernetes had no signal to act on. A manual pod restart fixed it instantly.

Root cause: TypeStream started each pipeline's `KafkaStreams` instance with no uncaught-exception handler, no state listener, and no health signal — so a wedge was invisible to k8s.

This makes a failed/wedged pipeline surface as an unhealthy process via a gRPC health check + liveness probe, and lets **Kubernetes restart the pod**. No in-process watchdog or restart supervisor.

## What changed

**Part 1 — surface failures + let k8s restart**
- `KafkaStreamsJob.start()` installs a **state listener** (diagnostic trail; none existed during the incident) and an **uncaught-exception handler** that returns `SHUTDOWN_CLIENT` on a fatal stream error (per-job, so one bad job doesn't kill in-process siblings) → job goes `ERROR` → `Job.State.FAILED`.
- `Server.kt` registers the standard **gRPC health service** and a **`HealthMonitor`** coroutine that reports `NOT_SERVING` when any managed job is `FAILED` or has been stuck non-`RUNNING` past a grace window (absorbs normal startup/rebalance).
- Native gRPC **`livenessProbe`** on port 4242 added to `cli/pkg/k8s/typestream.yaml.tmpl`.

**Part 2 — small hardening (both observed in the incident)**
- `KafkaClusterDirectory`: demote transient broker failures (`ConnectException`/`KafkaException`/`TimeoutException`, unwrapping causes) so the watcher no longer floods logs with a stack trace per tick (~18.9k during the outage), and **back off** the watcher ticks while the cluster is unreachable (`tick` gained exponential backoff).
- Make **`k8sMode` an explicit config flag** (default `false`) instead of DNS auto-detection, removing the startup `list jobs` **403** for in-process deployments. DNS detection still drives only the `/config` → `/etc/typestream` copy.

## Tests

Unit coverage (all green, 20 tests):
- `HealthMonitorTest` — SERVING / FAILED→NOT_SERVING / grace-window / recovery
- `KafkaStreamsJobTest` — uncaught-exception handler returns `SHUTDOWN_CLIENT`
- `TickTest` + `WatcherExceptionTest` — backoff math + transient-exception classifier
- `ConfigTest` — explicit `k8sMode` default-false / honored-when-set
- `HealthServiceTest` — integration test asserting the gRPC health check reports `SERVING`

## Follow-ups (out of scope for this repo)

- The homelab **Flux manifest** (`home-infrastructure-flux/apps/typestream/server-deployment.yaml`) needs the same `livenessProbe` block added in that repo.
- Deferred (documented in the plan): `state.dir` PVC persistence, explicit topology resource naming, and lag/progress-based health for the rare "RUNNING-but-hung" case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Review hardening (commit 16f02c9)

Post-review pass before merge (minimal scope):
- **startupProbe** added to the deployment template — slow boot (pipeline recovery / slow Kafka) gets ~300s to bind the gRPC port before liveness can fire.
- **Health grace window 5m → 15m** — a legitimately slow state restore (`REBALANCING → UNKNOWN`) is far less likely to be killed mid-restore.
- **HealthMonitor.run() guarded** — a transient failure reading job state (e.g. a concurrent-modification race in `scheduler.ps()`) can no longer escape the coroutine and cancel the server's root scope.

### Accepted tradeoffs / additional follow-ups (out of scope here)
- **Crash-loop blast radius:** a *deterministically*-failing pipeline (poison record / bad config) → `FAILED` → pod restart → `recoverPipelines()` replays it → loops, tearing down healthy in-process siblings each time. Inherent to in-process multi-pipeline + pod-restart; proper fix is progress-based health or per-pipeline isolation.
- **`scheduler.ps()` root cause:** `runningJobs.toList()` iterates a `synchronizedCollection` without holding its lock — should be `synchronized(runningJobs) { ... }`. The monitor guard contains the symptom; the root cause remains.
- **`Catalog` watcher** not given the same backoff/log-dampening; its handler re-throws non-`SocketException`.
- **No `NOT_SERVING` on shutdown** — a draining pod keeps reporting SERVING until the process dies.
- **`tick` backoff** abstraction is inert for all callers but `KafkaClusterDirectory`.
