### PR TITLE
chore(qdrant): bump Qdrant server to v1.18.2; document connector pin

### DIFF
--- a/cli/pkg/compose/Dockerfile.kafka-connect
+++ b/cli/pkg/compose/Dockerfile.kafka-connect
@@ -72,7 +72,14 @@ RUN cd /kafka/connect/weaviate-sink/Weaviate-kafka-connect-weaviate-${WEAVIATE_C
     curl -sLO https://repo1.maven.org/maven2/io/netty/netty-transport-native-unix-common/${NETTY_VERSION}/netty-transport-native-unix-common-${NETTY_VERSION}.jar
 
 # Install Qdrant Kafka Connect Sink connector
-# Distributed as a Confluent-archive ZIP with a single self-contained fat jar
+# Distributed as a Confluent-archive ZIP with a single self-contained fat jar.
+#
+# PINNED to 1.3.1 ON PURPOSE — do not bump without re-checking. v1.3.2 and v1.3.3
+# ship a shading regression: their shaded META-INF/services/shadow.grpc.NameResolverProvider
+# dropped the DnsNameResolverProvider entry, so any host:port qdrant.grpc.url fails at
+# runtime with "Address types of NameResolver 'unix' ... not supported". 1.3.1 is the
+# newest release whose services file still lists DnsNameResolverProvider. Before upgrading,
+# verify the target release's jar contains DnsNameResolverProvider in that services file.
 ENV QDRANT_CONNECTOR_VERSION=1.3.1
 
 RUN mkdir -p /kafka/connect/qdrant-sink && \

--- a/docker/Dockerfile.kafka-connect
+++ b/docker/Dockerfile.kafka-connect
@@ -76,7 +76,14 @@ RUN cd /kafka/connect/weaviate-sink/Weaviate-kafka-connect-weaviate-${WEAVIATE_C
     curl -sLO https://repo1.maven.org/maven2/io/netty/netty-transport-native-unix-common/${NETTY_VERSION}/netty-transport-native-unix-common-${NETTY_VERSION}.jar
 
 # Install Qdrant Kafka Connect Sink connector
-# Distributed as a Confluent-archive ZIP with a single self-contained fat jar
+# Distributed as a Confluent-archive ZIP with a single self-contained fat jar.
+#
+# PINNED to 1.3.1 ON PURPOSE — do not bump without re-checking. v1.3.2 and v1.3.3
+# ship a shading regression: their shaded META-INF/services/shadow.grpc.NameResolverProvider
+# dropped the DnsNameResolverProvider entry, so any host:port qdrant.grpc.url fails at
+# runtime with "Address types of NameResolver 'unix' ... not supported". 1.3.1 is the
+# newest release whose services file still lists DnsNameResolverProvider. Before upgrading,
+# verify the target release's jar contains DnsNameResolverProvider in that services file.
 ENV QDRANT_CONNECTOR_VERSION=1.3.1
 
 RUN mkdir -p /kafka/connect/qdrant-sink && \

--- a/examples/qdrant-live-rag/docker-compose.yml
+++ b/examples/qdrant-live-rag/docker-compose.yml
@@ -91,7 +91,7 @@ services:
       start_period: 30s
 
   qdrant:
-    image: qdrant/qdrant:v1.15.1
+    image: qdrant/qdrant:v1.18.2
     ports:
       - "6333:6333"  # REST
       - "6334:6334"  # gRPC


### PR DESCRIPTION
## What

Catches the Qdrant **server** up to the latest (v1.15.1 → **v1.18.2**) in the `qdrant-live-rag` example, and documents why the qdrant-kafka **connector** deliberately stays pinned at 1.3.1.

## Qdrant server: v1.15.1 → v1.18.2

Three minor versions behind. The demo only uses the stable REST surface (create-collection, upsert, search), so the bump is low-risk. Verified end-to-end on 1.18.2 — `docker compose up` seeds cleanly and the assistant answers correctly:

```
qdrant version: 1.18.2
points: 10
"How long is the free trial?" -> "The free trial is 14 days."
```

## Connector stays at 1.3.1 (on purpose)

The latest qdrant-kafka is v1.3.3 — but **v1.3.2 and v1.3.3 ship a shading regression** and there is no v1.3.4. Their shaded `META-INF/services/shadow.grpc.NameResolverProvider` dropped the `DnsNameResolverProvider` entry, so any `host:port` `qdrant.grpc.url` fails at runtime with:

```
Address types of NameResolver 'unix' for 'unix:///qdrant:6334' not supported by transport
```

Confirmed by jar-diffing the releases (1.3.1 lists `UdsNameResolverProvider` **and** `DnsNameResolverProvider`; 1.3.3 lists only the Uds one) and by watching the connector task crash live on 1.3.3. 1.3.1 is the newest release that still resolves `host:port`, so it stays pinned. This PR adds a prominent comment in **both** kafka-connect Dockerfiles (`docker/` and `cli/pkg/compose/`) explaining the pin and exactly what to verify before ever bumping it.

## Testing

- Brought the example up fresh on Qdrant v1.18.2: bootstrap exit 0, sink connector RUNNING, 10 points, chatbot correct (shown above).
- Connector regression re-verified this session via jar inspection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
