### PR TITLE
fix(uiv2): collapse qdrant envelope + intermediate sink into one Qdrant Sink node

### DIFF
--- a/uiv2/src/components/graph-builder/PipelineGraphViewer.tsx
+++ b/uiv2/src/components/graph-builder/PipelineGraphViewer.tsx
@@ -81,7 +81,9 @@ const nodeTitles: Record<string, string> = {
 const ViewerNode = memo(({ data, type = 'default' }: ViewerNodeProps) => {
   const theme = useTheme();
   const isSource = type === 'kafkaSource';
-  const isSink = type === 'kafkaSink';
+  // qdrantSink collapses the envelope + intermediate topic into one terminal node,
+  // so it's a sink for handle purposes just like kafkaSink.
+  const isSink = type === 'kafkaSink' || type === 'qdrantSink';
 
   // Get display value based on node type
   const displayValue = useMemo(() => {

--- a/uiv2/src/utils/graphDeserializer.ts
+++ b/uiv2/src/utils/graphDeserializer.ts
@@ -221,8 +221,28 @@ function applyDagreLayout(nodes: Node[], edges: Edge[]): Node[] {
  * Applies Dagre auto-layout since the server doesn't store positions.
  */
 export function deserializeGraph(graph: PipelineGraph): DeserializedGraph {
+  // The qdrantSink user node desugars to a qdrantEnvelope node feeding a generic
+  // sink that writes an internal intermediate topic (which the qdrant-kafka
+  // connector then drains into Qdrant). For display, collapse that pair into the
+  // single "Qdrant Sink" node so the graph mirrors the authored pipeline instead
+  // of showing a confusing "Qdrant Sink -> Kafka Sink" hop.
+  const nodeById = new Map(graph.nodes.map((n) => [n.id, n]));
+  const intermediateSinkIds = new Set<string>();
+  for (const edge of graph.edges) {
+    const from = nodeById.get(edge.fromId);
+    const to = nodeById.get(edge.toId);
+    if (from?.nodeType.case === 'qdrantEnvelope' && to?.nodeType.case === 'sink') {
+      intermediateSinkIds.add(edge.toId);
+    }
+  }
+
+  const visibleNodes = graph.nodes.filter((n) => !intermediateSinkIds.has(n.id));
+  const visibleEdges = graph.edges.filter(
+    (e) => !intermediateSinkIds.has(e.fromId) && !intermediateSinkIds.has(e.toId),
+  );
+
   // Convert proto nodes to React Flow nodes
-  const nodes: Node[] = graph.nodes.map((pipelineNode) => ({
+  const nodes: Node[] = visibleNodes.map((pipelineNode) => ({
     id: pipelineNode.id,
     type: getReactFlowNodeType(pipelineNode),
     position: { x: 0, y: 0 }, // Will be set by Dagre
@@ -235,7 +255,7 @@ export function deserializeGraph(graph: PipelineGraph): DeserializedGraph {
   }));
 
   // Convert proto edges to React Flow edges
-  const edges: Edge[] = graph.edges.map((pipelineEdge, index) => ({
+  const edges: Edge[] = visibleEdges.map((pipelineEdge, index) => ({
     id: `e${index}-${pipelineEdge.fromId}-${pipelineEdge.toId}`,
     source: pipelineEdge.fromId,
     target: pipelineEdge.toId,


### PR DESCRIPTION
## What

Cleans up the job-detail Pipeline Graph for Qdrant pipelines so it mirrors the authored pipeline.

## The problem

A `qdrantSink` user node desugars to a `qdrantEnvelope` node feeding a generic `sink` that writes an internal intermediate topic (which the qdrant-kafka connector then drains into Qdrant). The viewer rendered **both**, so the graph read as a confusing `… → Qdrant Sink → Kafka Sink (qdrant-sink-sink-1-…)` hop — as if Qdrant sinks into Kafka, and leaking the internal topic name.

Before:
```
Kafka Source → Embedding Generator → Qdrant Sink → Kafka Sink
                                     (help_articles)  (qdrant-sink-sink-1-…)
```

After:
```
Kafka Source → Embedding Generator → Qdrant Sink
                                     (help_articles)
```

## How

`graphDeserializer.deserializeGraph` now detects the `qdrantEnvelope → sink` pair and drops the intermediate sink node (and its edge) from the viewer, leaving the single terminal "Qdrant Sink" node. `PipelineGraphViewer` treats `qdrantSink` as a sink so the now-terminal node no longer draws a dangling output handle.

This is display-only (job-detail read-only viewer); the running topology is unchanged.

## Testing

uiv2 build + 83 tests pass. Verified live: built the UI image from this branch, swapped it into the running `qdrant-live-rag` stack, and confirmed the job graph renders the clean 3-node pipeline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
